### PR TITLE
fix: use sales channel language id for default customer

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,7 @@ services:
             [
                 "sh",
                 "-c",
-                "docker-entrypoint.sh mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --sql-require-primary-key=ON"
+                "docker-entrypoint.sh mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --sql-require-primary-key=ON"
             ]
 
         ports:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   },
   // We abuse this to wait for the external webserver
   webServer: {
-    command: 'docker compose up',
+    command: 'docker compose up --pull=always --quiet-pull shopware',
     url: process.env['APP_URL'],
     reuseExistingServer: true,
     timeout: 120000,

--- a/src/fixtures/DefaultSalesChannel.ts
+++ b/src/fixtures/DefaultSalesChannel.ts
@@ -249,6 +249,7 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
                 email: `customer_${id}@example.com`,
                 password: 'shopware',
                 salutationId: salutations.data[0].id,
+                languageId: SalesChannelBaseConfig.enGBLanguageId,
 
                 defaultShippingAddress: {
                     firstName: `${id} admin`,


### PR DESCRIPTION
The customer creation fails, if en-GB is not the default language.