### PR TITLE
feat: add dashboard and data sharing fixture

### DIFF
--- a/src/page-objects/AdministrationPages.ts
+++ b/src/page-objects/AdministrationPages.ts
@@ -7,6 +7,8 @@ import { CustomerDetail } from './administration/CustomerDetail';
 import { FirstRunWizard } from './administration/FirstRunWizard';
 import { FlowBuilderCreate } from './administration/FlowBuilderCreate';
 import { FlowBuilderListing } from './administration/FlowBuilderListing';
+import { DataSharing } from './administration/DataSharing';
+import { Dashboard } from './administration/Dashboard';
 
 export interface AdministrationPageTypes {
     AdminProductDetail: ProductDetail;
@@ -15,6 +17,8 @@ export interface AdministrationPageTypes {
     AdminFirstRunWizard: FirstRunWizard;
     AdminFlowBuilderCreate: FlowBuilderCreate;
     AdminFlowBuilderListing: FlowBuilderListing;
+    AdminDataSharing: DataSharing;
+    AdminDashboard: Dashboard;
 }
 
 export const AdminPageObjects = {
@@ -24,6 +28,8 @@ export const AdminPageObjects = {
     FirstRunWizard,
     FlowBuilderCreate,
     FlowBuilderListing,
+    Dashboard,
+    DataSharing,
 }
 
 export const test = base.extend<FixtureTypes>({
@@ -50,5 +56,13 @@ export const test = base.extend<FixtureTypes>({
 
     AdminFlowBuilderListing: async ({ AdminPage }, use) => {
         await use(new FlowBuilderListing(AdminPage));
+    },
+
+    AdminDataSharing: async ({ AdminPage }, use) => {
+        await use(new DataSharing(AdminPage));
+    },
+
+    AdminDashboard: async ({ AdminPage }, use) => {
+        await use(new Dashboard(AdminPage));
     },
 });

--- a/src/page-objects/administration/Dashboard.ts
+++ b/src/page-objects/administration/Dashboard.ts
@@ -1,0 +1,27 @@
+import type { Page, Locator } from '@playwright/test';
+import type { PageObject } from '../../types/PageObject';
+
+export class Dashboard implements PageObject {
+
+    public readonly dataSharingConsentBanner: Locator;
+    public readonly dataSharingAgreeButton: Locator;
+    public readonly dataSharingNotAtTheMomentButton: Locator;
+    public readonly dataSharingTermsAgreementLabel: Locator;
+    public readonly dataSharingSettingsLink: Locator;
+    public readonly dataSharingAcceptMessageText: Locator;
+    public readonly dataSharingNotAtTheMomentMessageText: Locator;
+
+    constructor(public readonly page: Page) {
+        this.dataSharingConsentBanner = page.locator('.sw-usage-data-consent-banner');
+        this.dataSharingAgreeButton = page.getByRole('button', { name: 'Agree' });
+        this.dataSharingNotAtTheMomentButton = page.getByRole('button', { name: 'Not at the moment' });
+        this.dataSharingSettingsLink = page.locator('.sw-usage-data-consent-banner-reject-accept-message').getByRole('link');
+        this.dataSharingAcceptMessageText = page.getByText('Thank you for your participation!');
+        this.dataSharingNotAtTheMomentMessageText = page.getByText('You can at any time enter into the agreement and thus contribute to and profit from the constant evolution of our services');
+        this.dataSharingTermsAgreementLabel = page.getByText('By clicking "Agree", you confirm that you are authorized to enter into this agreement on behalf of your company.');
+    }
+
+    async goTo() {
+        await this.page.goto('#/sw/dashboard/index');
+    }
+}

--- a/src/page-objects/administration/DataSharing.ts
+++ b/src/page-objects/administration/DataSharing.ts
@@ -1,0 +1,21 @@
+import type { Page, Locator } from '@playwright/test';
+import type { PageObject } from '../../types/PageObject';
+
+export class DataSharing implements PageObject {
+
+    public readonly dataSharingSuccessMessageLabel: Locator;
+    public readonly dataSharingAgreeButton: Locator;
+    public readonly dataSharingDisableButton: Locator;
+    public readonly dataSharingTermsAgreementLabel: Locator;
+
+    constructor(public readonly page: Page) {
+        this.dataSharingAgreeButton = page.getByRole('button', { name: 'Agree' });
+        this.dataSharingDisableButton = page.getByRole('button', { name: 'Disable data sharing' });
+        this.dataSharingSuccessMessageLabel = page.getByText('You are sharing data with us', { exact: true });
+        this.dataSharingTermsAgreementLabel = page.getByText('By clicking "Agree", you confirm that you are authorized to enter into this agreement on behalf of your company.');
+    }
+
+    async goTo() {
+        await this.page.goto('#/sw/settings/usage/data/index/general');
+    }
+}


### PR DESCRIPTION
Make the dashboard page and the data sharing page accessible for automated testing with playwright.