### PR TITLE
Refactor page object usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           with: # do not change the order of params
             target-branch: ${{ github.event.pull_request.base.ref }}  #required
             current-branch: ${{ github.event.pull_request.head.ref }} #required
-            pattern: '^\s*(feat|fix|ci|chore|docs|test|style|refactor)(\(.{1,}\))?: .{1,}$' #optional custom validation commit
+            pattern: '^\s*(feat|fix|ci|chore|docs|test|style|refactor|BREAKING CHANGE)(\(.{1,}\))?: .{1,}$' #optional custom validation commit
     test:
       timeout-minutes: 15
       runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ There are several page objects to navigate the different pages of the Administra
 ```TypeScript
 import { test, expect } from './../BaseTestFile';
 
-test('Storefront cart test scenario', async ({ StorefrontCheckoutCart }) => {
+test('Storefront cart test scenario', async ({ StorefrontPage, StorefrontCheckoutCart }) => {
 
-    await StorefrontCheckoutCart.goTo();
+    await StorefrontPage.goto(StorefrontCheckoutCart.url());
     await expect(StorefrontCheckoutCart.grandTotalPrice).toHaveText('€100.00*');
 });
 ```
@@ -236,7 +236,7 @@ The actor class is just a lightweight solution to simplify the execution of reus
 * `page`: A Playwright page context the actor is navigating.
 
 **Methods**  
-* `goesTo`: Accepts a page object the actor should be navigating to.
+* `goesTo`: Accepts an url of a page the actor should navigate to.
 * `attemptsTo`: Accepts a "task" function with reusable test logic the actor should perform.
 * `expects`: A one-to-one export of the Playwright `expect` method to use it in the actor pattern.
 
@@ -257,7 +257,7 @@ test('Product detail test scenario', async ({
     ProductData 
 }) => {
 
-    await ShopCustomer.goesTo(StorefrontProductDetail);
+    await ShopCustomer.goesTo(StorefrontProductDetail.url(ProductData));
     await ShopCustomer.attemptsTo(AddProductToCart(ProductData));
     await ShopCustomer.expects(StorefrontProductDetail.offCanvasSummaryTotalPrice).toHaveText('€99.99*');
 });
@@ -289,7 +289,7 @@ export const Login = base.extend<{ Login: Task }, FixtureTypes>({
             return async function Login() {
                 const { customer } = DefaultSalesChannel;
 
-                await ShopCustomer.goesTo(StorefrontAccountLogin);
+                await ShopCustomer.goesTo(StorefrontAccountLogin.url());
 
                 await StorefrontAccountLogin.emailInput.fill(customer.email);
                 await StorefrontAccountLogin.passwordInput.fill(customer.password);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1303,6 +1303,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@shopware/api-client/-/api-client-0.5.0.tgz",
       "integrity": "sha512-JrHbCurhJgFyjT4kDdcgSkTa3pxM2JwvUrgFYMYczdUP0NbHaP9Aq1hL4wWAgBn0Mvs3SDGu0nu34Ffu0dtB3A==",
+      "license": "MIT",
       "dependencies": {
         "ofetch": "^1.3.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.9.1",
-        "@playwright/test": "1.44.0",
+        "@playwright/test": "^1.44.1",
         "@shopware/api-client": "0.5.0",
         "axe-html-reporter": "2.2.3",
         "image-js": "0.35.5",
@@ -1109,11 +1109,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.44.0"
+        "playwright": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1777,12 +1778,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2681,10 +2683,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3108,6 +3111,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4329,11 +4333,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.44.0"
+        "playwright-core": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4346,9 +4351,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5220,6 +5226,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@playwright/test": "1.44.0",
+    "@playwright/test": "^1.44.1",
     "@shopware/api-client": "0.5.0",
     "@axe-core/playwright": "4.9.1",
     "axe-html-reporter": "2.2.3",

--- a/src/data-fixtures/Category/Category.ts
+++ b/src/data-fixtures/Category/Category.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../../types/FixtureTypes';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { Category } from '../../types/ShopwareTypes';
 
 export const CategoryData = base.extend<FixtureTypes>({
     CategoryData: async ({ IdProvider, AdminApiContext, DefaultSalesChannel, ProductData }, use) => {
@@ -26,7 +26,7 @@ export const CategoryData = base.extend<FixtureTypes>({
 
         expect(categoryResponse.ok()).toBeTruthy();
 
-        const { data: category } = (await categoryResponse.json()) as { data: components['schemas']['Category'] };
+        const { data: category } = (await categoryResponse.json()) as { data: Category };
 
         await use(category);
 

--- a/src/data-fixtures/DataFixtures.ts
+++ b/src/data-fixtures/DataFixtures.ts
@@ -10,11 +10,20 @@ import { MediaData } from './Media/Media';
 import { OrderData } from './Order/Order';
 import { TagData } from './Tag/Tag';
 
+export type ProductType = components['schemas']['Product'] & {
+    price: {
+        gross: number,
+        net: number,
+        linked: boolean,
+        currencyId: string,
+    }[]
+}
+
 export interface DataFixtureTypes {
-    ProductData: components['schemas']['Product'],
+    ProductData: ProductType,
     CategoryData: components['schemas']['Category'],
     DigitalProductData: {
-        product: components['schemas']['Product'],
+        product: ProductType,
         fileContent: string
     },
     PromotionWithCodeData: components['schemas']['Promotion'],

--- a/src/data-fixtures/DataFixtures.ts
+++ b/src/data-fixtures/DataFixtures.ts
@@ -1,5 +1,6 @@
 import { mergeTests } from '@playwright/test';
 import type { components } from '@shopware/api-client/admin-api-types';
+import type { Product, Category, Order } from '../types/ShopwareTypes';
 import { ProductData } from './Product/Product';
 import { CategoryData } from './Category/Category';
 import { DigitalProductData } from './Product/DigitalProduct';
@@ -10,21 +11,11 @@ import { MediaData } from './Media/Media';
 import { OrderData } from './Order/Order';
 import { TagData } from './Tag/Tag';
 
-export type ProductType = components['schemas']['Product'] & {
-    id: string,
-    price: {
-        gross: number,
-        net: number,
-        linked: boolean,
-        currencyId: string,
-    }[]
-}
-
 export interface DataFixtureTypes {
-    ProductData: ProductType,
-    CategoryData: components['schemas']['Category'],
+    ProductData: Product,
+    CategoryData: Category,
     DigitalProductData: {
-        product: ProductType,
+        product: Product,
         fileContent: string
     },
     PromotionWithCodeData: components['schemas']['Promotion'],
@@ -34,7 +25,7 @@ export interface DataFixtureTypes {
         propertyGroupSize: components['schemas']['PropertyGroup']
     },
     MediaData: components['schemas']['Media'],
-    OrderData: components['schemas']['Order'],
+    OrderData: Order,
     TagData: components['schemas']['Tag'],
 }
 

--- a/src/data-fixtures/DataFixtures.ts
+++ b/src/data-fixtures/DataFixtures.ts
@@ -11,6 +11,7 @@ import { OrderData } from './Order/Order';
 import { TagData } from './Tag/Tag';
 
 export type ProductType = components['schemas']['Product'] & {
+    id: string,
     price: {
         gross: number,
         net: number,

--- a/src/data-fixtures/Order/Order.ts
+++ b/src/data-fixtures/Order/Order.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../../types/FixtureTypes';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { Order } from '../../types/ShopwareTypes';
 import {
     getCurrency,
     getSalutationId,
@@ -226,7 +226,7 @@ export const OrderData = base.extend<FixtureTypes>({
 
         expect(orderResponse.ok()).toBeTruthy();
 
-        const { data: order } = (await orderResponse.json()) as { data: components['schemas']['Order'] };
+        const { data: order } = (await orderResponse.json()) as { data: Order };
 
         // Use order data in the test
         await use(order);

--- a/src/data-fixtures/Product/DigitalProduct.ts
+++ b/src/data-fixtures/Product/DigitalProduct.ts
@@ -1,5 +1,6 @@
 import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../../types/FixtureTypes';
+import type { Order } from '../../types/ShopwareTypes';
 import type { components } from '@shopware/api-client/admin-api-types';
 
 export const DigitalProductData = base.extend<FixtureTypes>({
@@ -58,7 +59,7 @@ export const DigitalProductData = base.extend<FixtureTypes>({
         });
         expect(orderSearchResponse.ok()).toBeTruthy();
 
-        const { data: ordersWithDigitalProduct } = (await orderSearchResponse.json()) as { data: components['schemas']['Order'][] };
+        const { data: ordersWithDigitalProduct } = (await orderSearchResponse.json()) as { data: Order[] };
 
         // Delete Orders using the digital product, to be able to delete the uploaded media file
         for (const order of ordersWithDigitalProduct) {

--- a/src/data-fixtures/Product/Product.ts
+++ b/src/data-fixtures/Product/Product.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../../types/FixtureTypes';
-import type { ProductType } from '../DataFixtures';
+import type { Product } from '../../types/ShopwareTypes';
 
 export const ProductData = base.extend<FixtureTypes>({
     ProductData: async ({ IdProvider, SalesChannelBaseConfig, AdminApiContext, DefaultSalesChannel }, use) => {
@@ -61,7 +61,7 @@ export const ProductData = base.extend<FixtureTypes>({
         });
         expect(productResponse.ok()).toBeTruthy();
 
-        const { data: product } = (await productResponse.json()) as { data: ProductType };
+        const { data: product } = (await productResponse.json()) as { data: Product };
 
         // Use product data in the test
         await use(product);

--- a/src/data-fixtures/Product/Product.ts
+++ b/src/data-fixtures/Product/Product.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../../types/FixtureTypes';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { ProductType } from '../DataFixtures';
 
 export const ProductData = base.extend<FixtureTypes>({
     ProductData: async ({ IdProvider, SalesChannelBaseConfig, AdminApiContext, DefaultSalesChannel }, use) => {
@@ -61,7 +61,7 @@ export const ProductData = base.extend<FixtureTypes>({
         });
         expect(productResponse.ok()).toBeTruthy();
 
-        const { data: product } = (await productResponse.json()) as { data: components['schemas']['Product'] };
+        const { data: product } = (await productResponse.json()) as { data: ProductType };
 
         // Use product data in the test
         await use(product);

--- a/src/fixtures/DefaultSalesChannel.ts
+++ b/src/fixtures/DefaultSalesChannel.ts
@@ -1,5 +1,6 @@
 import { test as base, expect, APIResponse } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
+import type { Customer } from '../types/ShopwareTypes';
 import type { components } from '@shopware/api-client/admin-api-types';
 import { createHash } from 'crypto';
 import {
@@ -33,7 +34,7 @@ export interface DefaultSalesChannelTypes {
     SalesChannelBaseConfig: StoreBaseConfig;
     DefaultSalesChannel: {
         salesChannel: components['schemas']['SalesChannel'];
-        customer: components['schemas']['Customer'] & { password: string };
+        customer: Customer;
         url: string;
     }
 }
@@ -295,7 +296,7 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
             expect(themeAssignResp.ok()).toBeTruthy();
             expect(salesChannelResp.ok()).toBeTruthy();
 
-            const customer = (await customerResp.json()) as { data: components['schemas']['Customer'] };
+            const customer = (await customerResp.json()) as { data: Customer };
             const salesChannel = (await salesChannelResp.json()) as { data: components['schemas']['SalesChannel'] };
 
             await use({

--- a/src/page-objects/AdministrationPages.ts
+++ b/src/page-objects/AdministrationPages.ts
@@ -7,6 +7,7 @@ import { CustomerDetail } from './administration/CustomerDetail';
 import { FirstRunWizard } from './administration/FirstRunWizard';
 import { FlowBuilderCreate } from './administration/FlowBuilderCreate';
 import { FlowBuilderListing } from './administration/FlowBuilderListing';
+import { FlowBuilderDetail } from './administration/FlowBuilderDetail';
 import { DataSharing } from './administration/DataSharing';
 import { Dashboard } from './administration/Dashboard';
 
@@ -17,6 +18,7 @@ export interface AdministrationPageTypes {
     AdminFirstRunWizard: FirstRunWizard;
     AdminFlowBuilderCreate: FlowBuilderCreate;
     AdminFlowBuilderListing: FlowBuilderListing;
+    AdminFlowBuilderDetail: FlowBuilderDetail;
     AdminDataSharing: DataSharing;
     AdminDashboard: Dashboard;
 }
@@ -28,22 +30,23 @@ export const AdminPageObjects = {
     FirstRunWizard,
     FlowBuilderCreate,
     FlowBuilderListing,
+    FlowBuilderDetail,
     Dashboard,
     DataSharing,
 }
 
 export const test = base.extend<FixtureTypes>({
 
-    AdminProductDetail: async ({ AdminPage, ProductData }, use) => {
-        await use(new ProductDetail(AdminPage, ProductData));
+    AdminProductDetail: async ({ AdminPage }, use) => {
+        await use(new ProductDetail(AdminPage));
     },
 
-    AdminOrderDetail: async ({ AdminPage, OrderData }, use) => {
-        await use(new OrderDetail(AdminPage, OrderData));
+    AdminOrderDetail: async ({ AdminPage }, use) => {
+        await use(new OrderDetail(AdminPage));
     },
 
-    AdminCustomerDetail: async ({ AdminPage, DefaultSalesChannel}, use) => {
-        await use(new CustomerDetail(AdminPage, DefaultSalesChannel.customer));
+    AdminCustomerDetail: async ({ AdminPage }, use) => {
+        await use(new CustomerDetail(AdminPage));
     },
 
     AdminFirstRunWizard: async ({ AdminPage }, use) => {
@@ -56,6 +59,10 @@ export const test = base.extend<FixtureTypes>({
 
     AdminFlowBuilderListing: async ({ AdminPage }, use) => {
         await use(new FlowBuilderListing(AdminPage));
+    },
+
+    AdminFlowBuilderDetail: async ({ AdminPage }, use) => {
+        await use(new FlowBuilderDetail(AdminPage));
     },
 
     AdminDataSharing: async ({ AdminPage }, use) => {

--- a/src/page-objects/StorefrontPages.ts
+++ b/src/page-objects/StorefrontPages.ts
@@ -59,12 +59,12 @@ export const test = base.extend<FixtureTypes>({
         await use(new Home(StorefrontPage));
     },
 
-    StorefrontProductDetail: async ({ StorefrontPage, ProductData }, use) => {
-        await use(new ProductDetail(StorefrontPage, ProductData));
+    StorefrontProductDetail: async ({ StorefrontPage }, use) => {
+        await use(new ProductDetail(StorefrontPage));
     },
 
-    StorefrontCategory: async ({ StorefrontPage, CategoryData }, use) => {
-        await use(new Category(StorefrontPage, CategoryData));
+    StorefrontCategory: async ({ StorefrontPage }, use) => {
+        await use(new Category(StorefrontPage));
     },
 
     StorefrontCheckoutCart: async ({ StorefrontPage }, use) => {

--- a/src/page-objects/administration/CustomerDetail.ts
+++ b/src/page-objects/administration/CustomerDetail.ts
@@ -12,7 +12,7 @@ export class CustomerDetail implements PageObject {
         this.accountCard = page.locator('.sw-customer-card')
     }
 
-    async goTo({ customerId }: Record<string, unknown>) {
-        await this.page.goto(`#/sw/customer/detail/${customerId}/base`);
+    url(customerId: string | undefined) {
+        return `#/sw/customer/detail/${customerId}/base`
     }
 }

--- a/src/page-objects/administration/CustomerDetail.ts
+++ b/src/page-objects/administration/CustomerDetail.ts
@@ -12,7 +12,7 @@ export class CustomerDetail implements PageObject {
         this.accountCard = page.locator('.sw-customer-card')
     }
 
-    url(customerId: string | undefined) {
+    url(customerId: string) {
         return `#/sw/customer/detail/${customerId}/base`
     }
 }

--- a/src/page-objects/administration/CustomerDetail.ts
+++ b/src/page-objects/administration/CustomerDetail.ts
@@ -1,24 +1,18 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { components } from '@shopware/api-client/admin-api-types';
 
 export class CustomerDetail implements PageObject {
-    public readonly customerId;
-    public readonly customer: components['schemas']['Customer'];
-
     public readonly editButton: Locator;
     public readonly generalTab: Locator;
     public readonly accountCard: Locator;
 
-    constructor(public readonly page: Page, customer: components['schemas']['Customer'] ) {
-        this.customerId = customer.id;
-        this.customer = customer;
+    constructor(public readonly page: Page) {
         this.editButton = page.getByRole('button', { name: 'Edit' });
         this.generalTab = page.getByRole('link', { name: 'General' });
         this.accountCard = page.locator('.sw-customer-card')
     }
 
-    async goTo() {
-        await this.page.goto(`#/sw/customer/detail/${this.customerId}/base`);
+    async goTo({ customerId }: Record<string, unknown>) {
+        await this.page.goto(`#/sw/customer/detail/${customerId}/base`);
     }
 }

--- a/src/page-objects/administration/Dashboard.ts
+++ b/src/page-objects/administration/Dashboard.ts
@@ -3,6 +3,8 @@ import type { PageObject } from '../../types/PageObject';
 
 export class Dashboard implements PageObject {
 
+    public readonly welcomeHeadline: Locator;
+
     public readonly dataSharingConsentBanner: Locator;
     public readonly dataSharingAgreeButton: Locator;
     public readonly dataSharingNotAtTheMomentButton: Locator;
@@ -12,6 +14,7 @@ export class Dashboard implements PageObject {
     public readonly dataSharingNotAtTheMomentMessageText: Locator;
 
     constructor(public readonly page: Page) {
+        this.welcomeHeadline = page.locator('h1.sw-dashboard-index__welcome-title');
         this.dataSharingConsentBanner = page.locator('.sw-usage-data-consent-banner');
         this.dataSharingAgreeButton = page.getByRole('button', { name: 'Agree' });
         this.dataSharingNotAtTheMomentButton = page.getByRole('button', { name: 'Not at the moment' });
@@ -21,7 +24,7 @@ export class Dashboard implements PageObject {
         this.dataSharingTermsAgreementLabel = page.getByText('By clicking "Agree", you confirm that you are authorized to enter into this agreement on behalf of your company.');
     }
 
-    async goTo() {
-        await this.page.goto('#/sw/dashboard/index');
+    url() {
+        return '#/sw/dashboard/index';
     }
 }

--- a/src/page-objects/administration/DataSharing.ts
+++ b/src/page-objects/administration/DataSharing.ts
@@ -3,19 +3,22 @@ import type { PageObject } from '../../types/PageObject';
 
 export class DataSharing implements PageObject {
 
+    public readonly dataConsentHeadline: Locator;
+
     public readonly dataSharingSuccessMessageLabel: Locator;
     public readonly dataSharingAgreeButton: Locator;
     public readonly dataSharingDisableButton: Locator;
     public readonly dataSharingTermsAgreementLabel: Locator;
 
     constructor(public readonly page: Page) {
+        this.dataConsentHeadline = page.locator('h3.sw-usage-data-consent-banner__content-headline');
         this.dataSharingAgreeButton = page.getByRole('button', { name: 'Agree' });
         this.dataSharingDisableButton = page.getByRole('button', { name: 'Disable data sharing' });
         this.dataSharingSuccessMessageLabel = page.getByText('You are sharing data with us', { exact: true });
         this.dataSharingTermsAgreementLabel = page.getByText('By clicking "Agree", you confirm that you are authorized to enter into this agreement on behalf of your company.');
     }
 
-    async goTo() {
-        await this.page.goto('#/sw/settings/usage/data/index/general');
+    url() {
+        return '#/sw/settings/usage/data/index/general';
     }
 }

--- a/src/page-objects/administration/FirstRunWizard.ts
+++ b/src/page-objects/administration/FirstRunWizard.ts
@@ -99,9 +99,9 @@ export class FirstRunWizard implements PageObject {
         this.documentationLink = page.locator('[href*="https://docs.shopware.com/en"]');
         this.forumLink = page.locator('[href*="https://forum.shopware.com/"]');
         this.roadmapLink = page.locator('[href*="https://www.shopware.com/en/roadmap/"]');
-
     }
-    async goTo() {
-        await this.page.goto(`#/sw/first/run/wizard/index/`);
+
+    url() {
+        return '#/sw/first/run/wizard/index/';
     }
 }

--- a/src/page-objects/administration/FlowBuilderCreate.ts
+++ b/src/page-objects/administration/FlowBuilderCreate.ts
@@ -11,7 +11,7 @@ export class FlowBuilderCreate implements PageObject {
         this.header = page.locator('h2');
     }
 
-    async goTo() {
-        await this.page.goto(`#/sw/flow/create/general`);
+    url() {
+        return '#/sw/flow/create/general';
     }
 }

--- a/src/page-objects/administration/FlowBuilderDetail.ts
+++ b/src/page-objects/administration/FlowBuilderDetail.ts
@@ -1,0 +1,19 @@
+import type { Page, Locator } from '@playwright/test';
+import type { PageObject } from '../../types/PageObject';
+
+export class FlowBuilderDetail implements PageObject {
+
+    public readonly saveButton: Locator;
+    public readonly generalTab: Locator;
+    public readonly flowTab: Locator;
+
+    constructor(public readonly page: Page) {
+        this.saveButton = page.locator('.sw-flow-detail__save');
+        this.generalTab = page.locator('.sw-flow-detail__tab-general');
+        this.flowTab = page.locator('.sw-flow-detail__tab-flow');
+    }
+
+    url(flowId: string, tabName? = 'general') {
+        return `#/sw/flow/detail/${flowId}/${tabName}`
+    }
+}

--- a/src/page-objects/administration/FlowBuilderDetail.ts
+++ b/src/page-objects/administration/FlowBuilderDetail.ts
@@ -13,7 +13,7 @@ export class FlowBuilderDetail implements PageObject {
         this.flowTab = page.locator('.sw-flow-detail__tab-flow');
     }
 
-    url(flowId: string, tabName? = 'general') {
+    url(flowId: string, tabName = 'general') {
         return `#/sw/flow/detail/${flowId}/${tabName}`
     }
 }

--- a/src/page-objects/administration/FlowBuilderListing.ts
+++ b/src/page-objects/administration/FlowBuilderListing.ts
@@ -3,6 +3,7 @@ import type { PageObject } from '../../types/PageObject';
 
 export class FlowBuilderListing implements PageObject {
 
+    public readonly createFlowButton: Locator;
     public readonly firstFlowName: Locator;
     public readonly firstFlowContextButton: Locator;
     public readonly flowContextMenu: Locator;
@@ -13,6 +14,7 @@ export class FlowBuilderListing implements PageObject {
     public readonly successAlertMessage: Locator;
 
     constructor(public readonly page: Page) {
+        this.createFlowButton = page.locator('.sw-flow-list__create');
         this.firstFlowName = page.locator('.sw-data-grid__cell--name a').first();
         this.firstFlowContextButton = page.locator('.sw-data-grid__actions-menu').first();
         this.flowContextMenu = page.locator('.sw-context-menu__content');
@@ -23,7 +25,7 @@ export class FlowBuilderListing implements PageObject {
         this.successAlertMessage = page.locator('.sw-alert__message');
     }
 
-    async goTo() {
-        await this.page.goto(`#/sw/flow/index/`);
+    url() {
+        return '#/sw/flow/index/';
     }
 }

--- a/src/page-objects/administration/OrderDetail.ts
+++ b/src/page-objects/administration/OrderDetail.ts
@@ -12,7 +12,7 @@ export class OrderDetail implements PageObject {
         this.orderTag = page.locator('.sw-select-selection-list__item');
     }
 
-    url(orderId: string | undefined) {
+    url(orderId: string) {
         return `#/sw/order/detail/${orderId}/general`;
     }
 }

--- a/src/page-objects/administration/OrderDetail.ts
+++ b/src/page-objects/administration/OrderDetail.ts
@@ -1,20 +1,16 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { components } from '@shopware/api-client/admin-api-types';
 
 export class OrderDetail implements PageObject {
     public readonly dataGridContextButton: Locator;
     public readonly orderTag: Locator;
 
-    public readonly orderData: components['schemas']['Order'];
-
-    constructor(public readonly page: Page, orderData: components['schemas']['Order']) {
-        this.orderData = orderData;
+    constructor(public readonly page: Page) {
         this.dataGridContextButton = page.locator('.sw-data-grid__actions-menu').and(page.getByRole('button'));
         this.orderTag = page.locator('.sw-select-selection-list__item');
     }
 
-    async goTo() {
-        await this.page.goto(`#/sw/order/detail/${this.orderData.id}/general`);
+    async goTo({ orderId }: Record<string, unknown>) {
+        await this.page.goto(`#/sw/order/detail/${orderId}/general`);
     }
 }

--- a/src/page-objects/administration/OrderDetail.ts
+++ b/src/page-objects/administration/OrderDetail.ts
@@ -2,15 +2,17 @@ import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
 
 export class OrderDetail implements PageObject {
+    public readonly saveButton: Locator;
     public readonly dataGridContextButton: Locator;
     public readonly orderTag: Locator;
 
     constructor(public readonly page: Page) {
+        this.saveButton = page.locator('.sw-order-detail__smart-bar-save-button');
         this.dataGridContextButton = page.locator('.sw-data-grid__actions-menu').and(page.getByRole('button'));
         this.orderTag = page.locator('.sw-select-selection-list__item');
     }
 
-    async goTo({ orderId }: Record<string, unknown>) {
-        await this.page.goto(`#/sw/order/detail/${orderId}/general`);
+    url(orderId: string | undefined) {
+        return `#/sw/order/detail/${orderId}/general`;
     }
 }

--- a/src/page-objects/administration/ProductDetail.ts
+++ b/src/page-objects/administration/ProductDetail.ts
@@ -1,6 +1,6 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { ProductType } from '../../data-fixtures/DataFixtures';
 
 export class ProductDetail implements PageObject {
 
@@ -46,9 +46,9 @@ export class ProductDetail implements PageObject {
     public readonly propertyOptionSizeMedium: Locator;
     public readonly propertyOptionSizeLarge: Locator;
 
-    public readonly productData: components['schemas']['Product'];
+    public readonly productData: ProductType;
 
-    constructor(public readonly page: Page, productData: components['schemas']['Product']) {
+    constructor(public readonly page: Page, productData: ProductType) {
         this.productData = productData;
 
         this.savePhysicalProductButton = page.getByRole('button', { name: 'Save' });
@@ -77,10 +77,9 @@ export class ProductDetail implements PageObject {
         this.propertyOptionSizeSmall = this.propertyOptionGrid.getByLabel('Small');
         this.propertyOptionSizeMedium = this.propertyOptionGrid.getByLabel('Medium');
         this.propertyOptionSizeLarge = this.propertyOptionGrid.getByLabel('Large');
-
     }
 
-    async goTo() {
+    async goTo({ orderId }: Record<string, unknown>) {
         await this.page.goto(`#/sw/product/detail/${this.productData.id}/base`);
     }
 

--- a/src/page-objects/administration/ProductDetail.ts
+++ b/src/page-objects/administration/ProductDetail.ts
@@ -1,6 +1,5 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { ProductType } from '../../data-fixtures/DataFixtures';
 
 export class ProductDetail implements PageObject {
 
@@ -46,10 +45,7 @@ export class ProductDetail implements PageObject {
     public readonly propertyOptionSizeMedium: Locator;
     public readonly propertyOptionSizeLarge: Locator;
 
-    public readonly productData: ProductType;
-
-    constructor(public readonly page: Page, productData: ProductType) {
-        this.productData = productData;
+    constructor(public readonly page: Page) {
 
         this.savePhysicalProductButton = page.getByRole('button', { name: 'Save' });
         this.saveButtonCheckMark = page.locator('.icon--regular-checkmark-xs');
@@ -79,11 +75,7 @@ export class ProductDetail implements PageObject {
         this.propertyOptionSizeLarge = this.propertyOptionGrid.getByLabel('Large');
     }
 
-    async goTo({ orderId }: Record<string, unknown>) {
-        await this.page.goto(`#/sw/product/detail/${this.productData.id}/base`);
-    }
-
-    getProductId(){
-        return this.productData.id;
+    url(productId: string) {
+        return `#/sw/product/detail/${productId}/base`
     }
 }

--- a/src/page-objects/storefront/Account.ts
+++ b/src/page-objects/storefront/Account.ts
@@ -20,7 +20,7 @@ export class Account implements PageObject {
         this.newsletterRegistrationSuccessMessage = page.getByText('You have successfully subscribed to the newsletter.');
     }
 
-    async goTo() {
-        await this.page.goto('account');
+    url() {
+        return 'account';
     }
 }

--- a/src/page-objects/storefront/AccountAddresses.ts
+++ b/src/page-objects/storefront/AccountAddresses.ts
@@ -16,7 +16,7 @@ export class AccountAddresses implements PageObject {
         this.useDefaultShippingAddressButton = page.getByRole('button', { name: 'Use as default shipping address' });
     }
 
-    async goTo() {
-        await this.page.goto('account/address');
+    url() {
+        return 'account/address';
     }
 }

--- a/src/page-objects/storefront/AccountLogin.ts
+++ b/src/page-objects/storefront/AccountLogin.ts
@@ -40,7 +40,7 @@ export class AccountLogin implements PageObject {
         this.successAlert = page.getByText('Successfully logged out.');
     }
 
-    async goTo() {
-        await this.page.goto('account/login');
+    url() {
+        return 'account/login';
     }
 }

--- a/src/page-objects/storefront/AccountOrder.ts
+++ b/src/page-objects/storefront/AccountOrder.ts
@@ -13,7 +13,7 @@ export class AccountOrder implements PageObject {
         this.digitalProductDownloadButton = page.getByRole('link', { name: 'Download' }).first();
     }
 
-    async goTo() {
-        await this.page.goto('account/order');
+    url() {
+        return 'account/order';
     }
 }

--- a/src/page-objects/storefront/AccountPayment.ts
+++ b/src/page-objects/storefront/AccountPayment.ts
@@ -14,7 +14,7 @@ export class AccountPayment implements PageObject {
         this.changeDefaultPaymentButton = page.getByRole('button', { name: 'Change' });
     }
 
-    async goTo() {
-        await this.page.goto('account/payment');
+    url() {
+        return 'account/payment';
     }
 }

--- a/src/page-objects/storefront/AccountProfile.ts
+++ b/src/page-objects/storefront/AccountProfile.ts
@@ -38,7 +38,7 @@ export class AccountProfile implements PageObject {
         this.saveNewPasswordButton = page.locator('#profilePasswordForm').getByRole('button', { name: 'Save changes' });
     }
 
-    async goTo() {
-        await this.page.goto('account/profile');
+    url() {
+        return 'account/profile';
     }
 }

--- a/src/page-objects/storefront/Category.ts
+++ b/src/page-objects/storefront/Category.ts
@@ -1,24 +1,18 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { components } from '@shopware/api-client/admin-api-types';
 
 export class Category implements PageObject {
-    public readonly categoryData: components['schemas']['Category'];
-
     public readonly sortingSelect: Locator;
     public readonly firstProductBuyButton: Locator;
     public readonly noProductsFoundAlert: Locator;
 
-    constructor(public readonly page: Page, CategoryData: components['schemas']['Category']) {
-        this.categoryData = CategoryData;
-
+    constructor(public readonly page: Page) {
         this.sortingSelect = page.getByLabel('Sorting');
         this.firstProductBuyButton = page.getByRole('button', { name: 'Add to shopping cart' }).first();
         this.noProductsFoundAlert = page.getByText('No products found.');
     }
 
-    async goTo() {
-        const url = `${this.categoryData.name}`;
-        await this.page.goto(url);
+    url(categoryName: string): string {
+        return `${categoryName}`;
     }
 }

--- a/src/page-objects/storefront/CheckoutCart.ts
+++ b/src/page-objects/storefront/CheckoutCart.ts
@@ -22,7 +22,7 @@ export class CheckoutCart implements PageObject {
         this.unitPriceInfo = page.locator('.line-item-unit-price-value');
     }
 
-    async goTo() {
-        await this.page.goto('checkout/cart');
+    url() {
+        return 'checkout/cart';
     }
 }

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -43,7 +43,7 @@ export class CheckoutConfirm implements PageObject {
         this.cartLineItemImages = page.locator('.line-item-img-link');
     }
 
-    async goTo() {
-        await this.page.goto('checkout/confirm');
+    url() {
+        return 'checkout/confirm';
     }
 }

--- a/src/page-objects/storefront/CheckoutFinish.ts
+++ b/src/page-objects/storefront/CheckoutFinish.ts
@@ -16,8 +16,8 @@ export class CheckoutFinish implements PageObject {
         this.cartLineItemImages = page.locator('.line-item-img-link');
     }
 
-    async goTo() {
-        console.error('The checkout finish page should only be navigated to via checkout action.')
+    url() {
+        return 'checkout/finish';
     }
 
     async getOrderNumber(): Promise<string | null> {

--- a/src/page-objects/storefront/CheckoutRegister.ts
+++ b/src/page-objects/storefront/CheckoutRegister.ts
@@ -9,7 +9,7 @@ export class CheckoutRegister implements PageObject {
         this.cartLineItemImages = page.locator('.line-item-img-link');
     }
 
-    async goTo() {
-        await this.page.goto('checkout/register');
+    url() {
+        return 'checkout/register';
     }
 }

--- a/src/page-objects/storefront/Home.ts
+++ b/src/page-objects/storefront/Home.ts
@@ -9,7 +9,7 @@ export class Home implements PageObject {
         this.productImages = page.locator('.product-image-link');
     }
 
-    async goTo() {
-        await this.page.goto('./');
+    url() {
+        return '/';
     }
 }

--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -1,6 +1,6 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { ProductType } from '../../data-fixtures/DataFixtures';
 
 export class ProductDetail implements PageObject {
     public readonly addToCartButton: Locator;
@@ -16,7 +16,7 @@ export class ProductDetail implements PageObject {
 
     constructor(
         public readonly page: Page,
-        public readonly productData: components['schemas']['Product']
+        public readonly productData: ProductType
     ) {
         this.addToCartButton = page.getByRole('button', { name: 'Add to shopping cart' });
         this.offCanvasCartTitle = page.getByText('Shopping cart', { exact: true });
@@ -30,7 +30,7 @@ export class ProductDetail implements PageObject {
         this.productSingleImage = page.locator('.gallery-slider-single-image');
     }
 
-    async goTo(productData: components['schemas']['Product'] = this.productData) {
+    async goTo(productData: ProductType = this.productData) {
         let namePath = '';
         if (productData.translated && productData.translated.name) {
             namePath = productData.translated.name.replaceAll('_', '-');

--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -1,6 +1,6 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import type { ProductType } from '../../data-fixtures/DataFixtures';
+import type { Product } from '../../types/ShopwareTypes';
 
 export class ProductDetail implements PageObject {
 
@@ -29,7 +29,7 @@ export class ProductDetail implements PageObject {
         this.offCanvasSummaryTotalPrice = page.locator('.offcanvas-summary').locator('dt:has-text("Subtotal") + dd');
     }
 
-    url(productData: ProductType) {
+    url(productData: Product) {
         let namePath = '';
         if (productData.translated && productData.translated.name) {
             namePath = productData.translated.name.replaceAll('_', '-');

--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -3,41 +3,38 @@ import type { PageObject } from '../../types/PageObject';
 import type { ProductType } from '../../data-fixtures/DataFixtures';
 
 export class ProductDetail implements PageObject {
+
     public readonly addToCartButton: Locator;
+    public readonly quantitySelect: Locator;
+    public readonly productSingleImage: Locator;
 
     public readonly offCanvasCartTitle: Locator;
     public readonly offCanvasCart: Locator;
     public readonly offCanvasCartGoToCheckoutButton: Locator;
-    public readonly productSingleImage: Locator;
     public readonly offCanvasLineItemImages: Locator;
-    public readonly quantitySelect: Locator;
     public readonly offCanvasSummaryTotalPrice: Locator;
     public readonly offCanvas: Locator;
 
-    constructor(
-        public readonly page: Page,
-        public readonly productData: ProductType
-    ) {
+    constructor(public readonly page: Page) {
+
         this.addToCartButton = page.getByRole('button', { name: 'Add to shopping cart' });
+        this.quantitySelect = page.getByLabel('Quantity', { exact: true });
+        this.productSingleImage = page.locator('.gallery-slider-single-image');
+
+        this.offCanvas = page.locator('offcanvas-body');
         this.offCanvasCartTitle = page.getByText('Shopping cart', { exact: true });
         this.offCanvasCart = page.getByRole('dialog');
         this.offCanvasCartGoToCheckoutButton = page.getByRole('link', { name: 'Go to checkout' });
         this.offCanvasLineItemImages = page.locator('.line-item-img-link');
-        this.quantitySelect = page.getByLabel('Quantity', { exact: true });
-        this.offCanvas = page.locator('offcanvas-body');
         this.offCanvasSummaryTotalPrice = page.locator('.offcanvas-summary').locator('dt:has-text("Subtotal") + dd');
-
-        this.productSingleImage = page.locator('.gallery-slider-single-image');
     }
 
-    async goTo(productData: ProductType = this.productData) {
+    url(productData: ProductType) {
         let namePath = '';
         if (productData.translated && productData.translated.name) {
             namePath = productData.translated.name.replaceAll('_', '-');
         }
 
-        const url = `${namePath}/${productData.productNumber}`;
-
-        await this.page.goto(url);
+       return `${namePath}/${productData.productNumber}`;
     }
 }

--- a/src/page-objects/storefront/Search.ts
+++ b/src/page-objects/storefront/Search.ts
@@ -3,14 +3,15 @@ import type { PageObject } from '../../types/PageObject';
 
 export class Search implements PageObject {
 
+    public readonly headline: Locator;
     public readonly productImages: Locator;
 
     constructor(public readonly page: Page) {
+        this.headline = page.locator('h1.search-headline');
         this.productImages = page.locator('.product-image-link');
     }
 
-    async goTo() {
-        const url = `search?search`;
-        await this.page.goto(url);
+    url(searchTerm: string) {
+        return `search?search=${searchTerm}`;
     }
 }

--- a/src/page-objects/storefront/SearchSuggest.ts
+++ b/src/page-objects/storefront/SearchSuggest.ts
@@ -9,8 +9,7 @@ export class SearchSuggest implements PageObject {
         this.searchSuggestLineItemImages = page.locator('.search-suggest-product-image-container');
     }
 
-    async goTo() {
-        const url = `suggest?search`;
-        await this.page.goto(url);
+    url(searchTerm: string) {
+        return `suggest?search=${searchTerm}`;
     }
 }

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import type { PageObject } from '../types/PageObject';
 
 export class Actor {
     public page: Page;
@@ -18,11 +17,11 @@ export class Actor {
         await test.step(stepTitle, async () => await task());
     }
 
-    async goesTo(pageObject: PageObject, params?: Record<string, unknown>) {
-        const stepTitle = `${this.name} navigates to ${this.camelCaseToLowerCase(pageObject.constructor.name)}`;
+    async goesTo(url: string) {
+        const stepTitle = `${this.name} navigates to "${url}"`;
 
         await test.step(stepTitle, async () => {
-            await pageObject.goTo(params);
+            await this.page.goto(url);
 
             await this.page.addStyleTag({
                 content: `

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -18,11 +18,11 @@ export class Actor {
         await test.step(stepTitle, async () => await task());
     }
 
-    async goesTo(pageObject: PageObject) {
+    async goesTo(pageObject: PageObject, params?: Record<string, unknown>) {
         const stepTitle = `${this.name} navigates to ${this.camelCaseToLowerCase(pageObject.constructor.name)}`;
 
         await test.step(stepTitle, async () => {
-            await pageObject.goTo();
+            await pageObject.goTo(params);
 
             await this.page.addStyleTag({
                 content: `

--- a/src/tasks/shop-customer/Account/Login.ts
+++ b/src/tasks/shop-customer/Account/Login.ts
@@ -8,7 +8,7 @@ export const Login = base.extend<{ Login: Task }, FixtureTypes>({
             return async function Login() {
                 const { customer } = DefaultSalesChannel;
 
-                await ShopCustomer.goesTo(StorefrontAccountLogin);
+                await ShopCustomer.goesTo(StorefrontAccountLogin.url());
 
                 await StorefrontAccountLogin.emailInput.fill(customer.email);
                 await StorefrontAccountLogin.passwordInput.fill(customer.password);

--- a/src/tasks/shop-customer/Account/Logout.ts
+++ b/src/tasks/shop-customer/Account/Logout.ts
@@ -7,7 +7,7 @@ export const Logout = base.extend<{ Logout: Task }, FixtureTypes>({
         const task = () => {
             return async function Logout() {
 
-                await ShopCustomer.goesTo(StorefrontAccountLogin);
+                await ShopCustomer.goesTo(StorefrontAccountLogin.url());
                 await ShopCustomer.expects(StorefrontAccountLogin.loginButton).not.toBeVisible();
 
                 await StorefrontAccountLogin.logoutLink.click();

--- a/src/tasks/shop-customer/Product/AddProductToCart.ts
+++ b/src/tasks/shop-customer/Product/AddProductToCart.ts
@@ -1,11 +1,11 @@
 import { test as base } from '@playwright/test';
 import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
-import type { components } from '@shopware/api-client/admin-api-types';
+import type { ProductType } from '../../../data-fixtures/DataFixtures';
 
 export const AddProductToCart = base.extend<{ AddProductToCart: Task }, FixtureTypes>({
     AddProductToCart: async ({ ShopCustomer, StorefrontProductDetail }, use)=> {
-        const task = (ProductData: components['schemas']['Product'], quantity = '1') => {
+        const task = (ProductData: ProductType, quantity = '1') => {
             return async function AddProductToCart() {
                 await StorefrontProductDetail.quantitySelect.fill(quantity);
 

--- a/src/types/PageObject.ts
+++ b/src/types/PageObject.ts
@@ -3,5 +3,5 @@ import type { Page } from '@playwright/test';
 export interface PageObject {
     readonly page: Page;
 
-    goTo(): Promise<void>;
+    goTo(params?: Record<string, unknown>): Promise<void>;
 }

--- a/src/types/PageObject.ts
+++ b/src/types/PageObject.ts
@@ -3,5 +3,5 @@ import type { Page } from '@playwright/test';
 export interface PageObject {
     readonly page: Page;
 
-    goTo(params?: Record<string, unknown>): Promise<void>;
+    url(...args: unknown[]): string;
 }

--- a/src/types/ShopwareTypes.ts
+++ b/src/types/ShopwareTypes.ts
@@ -1,0 +1,24 @@
+import type { components } from '@shopware/api-client/admin-api-types';
+
+export type Customer = components['schemas']['Customer'] & {
+    id: string,
+    password: string,
+}
+
+export type Product = components['schemas']['Product'] & {
+    id: string,
+    price: {
+        gross: number,
+        net: number,
+        linked: boolean,
+        currencyId: string,
+    }[]
+}
+
+export type Category = components['schemas']['Category'] & {
+    id: string,
+}
+
+export type Order = components['schemas']['Order'] & {
+    id: string,
+}

--- a/tests/PageObjects.spec.ts
+++ b/tests/PageObjects.spec.ts
@@ -1,0 +1,110 @@
+import { test, getFlowId } from '../src/index';
+
+test('Storefront page objects.', async ({
+    ShopCustomer,
+    ProductData,
+    CategoryData,
+    Login,
+    AddProductToCart,
+    ConfirmTermsAndConditions,
+    SubmitOrder,
+    StorefrontProductDetail,
+    StorefrontCategory,
+    StorefrontCheckoutCart,
+    StorefrontCheckoutConfirm,
+    StorefrontCheckoutFinish,
+    StorefrontAccount,
+    StorefrontAccountLogin,
+    StorefrontAccountProfile,
+    StorefrontAccountOrder,
+    StorefrontAccountAddresses,
+    StorefrontAccountPayment,
+    StorefrontSearch,
+}) => {
+
+    await ShopCustomer.goesTo(StorefrontAccountLogin.url());
+    await ShopCustomer.expects(StorefrontAccountLogin.loginButton).toBeVisible();
+    await ShopCustomer.attemptsTo(Login());
+
+    await ShopCustomer.goesTo(StorefrontProductDetail.url(ProductData));
+    await ShopCustomer.expects(StorefrontProductDetail.addToCartButton).toBeVisible();
+    await ShopCustomer.attemptsTo(AddProductToCart(ProductData));
+
+    await ShopCustomer.goesTo(StorefrontCategory.url(CategoryData.name));
+    await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontCheckoutCart.url());
+    await ShopCustomer.expects(StorefrontCheckoutCart.grandTotalPrice).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontCheckoutConfirm.url());
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeVisible();
+
+    await ShopCustomer.attemptsTo(ConfirmTermsAndConditions());
+    await ShopCustomer.attemptsTo(SubmitOrder());
+    await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontAccount.url());
+    await ShopCustomer.expects(StorefrontAccount.headline).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontAccountOrder.url());
+    await ShopCustomer.expects(StorefrontAccountOrder.orderExpandButton).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontAccountProfile.url());
+    await ShopCustomer.expects(StorefrontAccountProfile.changeEmailButton).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontAccountPayment.url());
+    await ShopCustomer.expects(StorefrontAccountPayment.changeDefaultPaymentButton).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontAccountAddresses.url());
+    await ShopCustomer.expects(StorefrontAccountAddresses.addNewAddressButton).toBeVisible();
+
+    const searchTerm = 'product';
+    await ShopCustomer.goesTo(StorefrontSearch.url(searchTerm));
+    await ShopCustomer.expects(StorefrontSearch.headline).toBeVisible();
+});
+
+test('Administration page objects.', async ({
+    AdminApiContext,
+    ShopAdmin,
+    ProductData,
+    OrderData,
+    DefaultSalesChannel,
+    AdminProductDetail,
+    AdminOrderDetail,
+    AdminCustomerDetail,
+    AdminFirstRunWizard,
+    AdminFlowBuilderCreate,
+    AdminFlowBuilderListing,
+    AdminFlowBuilderDetail,
+    AdminDataSharing,
+    AdminDashboard,
+}) => {
+
+    await ShopAdmin.goesTo(AdminFirstRunWizard.url());
+    await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminProductDetail.url(ProductData.id));
+    await ShopAdmin.expects(AdminProductDetail.savePhysicalProductButton).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminOrderDetail.url(OrderData.id));
+    await ShopAdmin.expects(AdminOrderDetail.saveButton).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminCustomerDetail.url(DefaultSalesChannel.customer.id));
+    await ShopAdmin.expects(AdminCustomerDetail.accountCard).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminFlowBuilderCreate.url());
+    await ShopAdmin.expects(AdminFlowBuilderCreate.saveButton).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
+    await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
+
+    const flowId = await getFlowId('Order enters status unconfirmed', AdminApiContext);
+    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
+    await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminDashboard.url());
+    await ShopAdmin.expects(AdminDashboard.welcomeHeadline).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminDataSharing.url());
+    await ShopAdmin.expects(AdminDataSharing.dataConsentHeadline).toBeVisible();
+});


### PR DESCRIPTION
To remove the hard dependency between data fixtures and page objects, I removed the usage of the page objects `goTo` method and refactored the way the `goesTo()` method of the actor works.

This has the following advantages:
- No dependency between data fixtures and page objects
- The `goesTo()` method of the actor now uses a url instead of a page object which makes the usage more flexible.
- The page objects have a new parameterized `url()` method which can be used in combination with the changed `goesTo()` method.

Before:
```
await ShopCustomer.goesTo(StorefrontProductDetail);
```

After:
```
await ShopCustomer.goesTo(StorefrontProductDetail.url(ProductData));
```

I also added a test for the general usage of all page objects.