### PR TITLE
feat: make theme compilation compatible with SaaS instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "lint:fix": "npm run lint --fix",
+    "lint:fix": "npm run lint -- --fix",
     "build": "npx unbuild",
     "prepublishOnly": "npm run build"
   },

--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -1,17 +1,56 @@
-import { test as base } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
 import { IdProvider } from '../services/IdProvider';
+import { isSaaSInstance } from '../services/ShopInfo';
+import type { FixtureTypes } from '../types/FixtureTypes';
 
 export interface HelperFixtureTypes {
     IdProvider: IdProvider;
+    SaaSInstanceSetup: () => Promise<void>,
 }
 
-export const test = base.extend<NonNullable<unknown>, HelperFixtureTypes>({
+export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
     IdProvider: [
-        async ({}, use, workerInfo)=> {
+        async ({ }, use, workerInfo) => {
             const seed = process.env.SHOPWARE_ACCESS_KEY_ID || process.env.SHOPWARE_ADMIN_PASSWORD || 'test-suite';
-            const idProvider = new IdProvider(workerInfo.workerIndex, seed);
+            const idProvider = new IdProvider(workerInfo.parallelIndex, seed);
 
             await use(idProvider);
+        },
+        { scope: 'worker' },
+    ],
+
+    SaaSInstanceSetup: [
+        async ({ AdminApiContext, browser }, use) => {
+            const SetupInstance = async function SetupInstance() {
+                // eslint-disable-next-line playwright/no-skipped-test
+                await test.skip(!(await isSaaSInstance(AdminApiContext)), 'Skipping SaaS setup, could not detect SaaS instance');
+
+                // check tags
+                const instanceStatusResponse = await AdminApiContext.get('./instance/status');
+                const instanceStatus = await instanceStatusResponse.json() as { name: string, inStatusSince: string, tags: [string] };
+
+                await expect(instanceStatus.tags, 'expect instance to have "ci" tag').toContain('ci');
+
+                // eslint-disable-next-line playwright/no-skipped-test
+                await test.skip((await AdminApiContext.get(`${process.env.APP_URL}constructionmode`, { maxRedirects: 0 })).status() > 204, 'Instance already setup');
+
+                const page = await browser.newPage({ baseURL: process.env.ADMIN_URL });
+
+                await page.goto('./set-up-shop');
+                await page.getByRole('button', { name: 'Next' }).click();
+
+                await expect(page.getByRole('heading', { name: 'Everything finished!' })).toBeVisible();
+
+                await page.getByRole('button', { name: 'Open your shop' }).click();
+                await page.goto(`${process.env.ADMIN_URL}`);
+                await page.getByLabel(/Username|Email address/).fill(AdminApiContext.options.admin_username ?? 'admin');
+                await page.getByLabel('Password').fill(AdminApiContext.options.admin_password ?? 'shopware');
+                await page.getByRole('button', { name: 'Log in' }).click();
+
+                await page.getByRole('button', { name: 'Launch your business' }).click();
+            };
+
+            await use(SetupInstance);
         },
         { scope: 'worker' },
     ],

--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -19,8 +19,8 @@ export interface AdminApiContextOptions {
 
 export class AdminApiContext {
 
-    private context: APIRequestContext;
-    private readonly options: AdminApiContextOptions;
+    public context: APIRequestContext;
+    public readonly options: AdminApiContextOptions;
 
     private static readonly defaultOptions: AdminApiContextOptions = {
         app_url: process.env['APP_URL'],

--- a/src/services/ApiMocks.ts
+++ b/src/services/ApiMocks.ts
@@ -1,0 +1,40 @@
+import { Page } from '@playwright/test';
+
+export async function mockApiCalls(page: Page) {
+    await page.route('**/api/notification/message*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notifications: [], timestamp: '2024-06-19 06:23:25.040' }),
+    }));
+
+    // the SBP calls do not work for non-sbp users (which are created by the ATS)
+    await page.route('**/api/_action/store/plugin/search*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0 }),
+    }));
+
+    await page.route('**/api/_action/store/updates*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0 }),
+    }));
+
+    await page.route('**/api/sbp/shop-info*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0 }),
+    }));
+
+    await page.route('**/api/sbp/shop-info*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: process.env.SBP_SHOP_INFO_JSON ?? '{}',
+    }));
+
+    await page.route('**/api/sbp/bookableplans*', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: process.env.SBP_BOOKABLE_PLANS_JSON ?? '{}',
+    }));
+}

--- a/src/services/ShopwareDataHelpers.ts
+++ b/src/services/ShopwareDataHelpers.ts
@@ -43,7 +43,7 @@ export const getSnippetSetId = async (languageCode: string, adminApiContext: Adm
     return result.data[0].id;
 };
 
-export const getCurrency = async (isoCode: 'EUR', adminApiContext: AdminApiContext) => {
+export const getCurrency = async (isoCode: string, adminApiContext: AdminApiContext) => {
     const resp = await adminApiContext.post('search/currency', {
         data: {
             limit: 1,
@@ -207,7 +207,7 @@ export const getFlowId = async (flowName: string, adminApiContext: AdminApiConte
     return result.data[0].id;
 };
 
-export const getOrderTransactionId = async (orderId: string, adminApiContext: AdminApiContext): Promise<{ id: string }> =>{
+export const getOrderTransactionId = async (orderId: string, adminApiContext: AdminApiContext): Promise<{ id: string }> => {
     const orderTransactionResponse = await adminApiContext.get(`order/${orderId}/transactions?_response`);
 
     const { data: orderTransaction } = await orderTransactionResponse.json();
@@ -237,6 +237,6 @@ export function extractIdFromUrl(url: string): string | null {
 }
 
 type OrderStatus = 'cancel' | 'complete' | 'reopen' | 'process';
-export const setOrderStatus = async (orderId: string, orderStatus: OrderStatus , adminApiContext: AdminApiContext): Promise<APIResponse> => {
+export const setOrderStatus = async (orderId: string, orderStatus: OrderStatus, adminApiContext: AdminApiContext): Promise<APIResponse> => {
     return await adminApiContext.post(`./_action/order/${orderId}/state/${orderStatus}`);
 };


### PR DESCRIPTION
- fix waiting for theme compilation in SaaS
- add SetupSaaS task
- remove theme caching for now, because it does not work in all environments
- use `parallelIndex` instead of `workerIndex` to prevent unnecessary creation of different worker fixtures (for example when one test fails, it will use a different workerIndex after that)
- mock sbp calls, that fail for users that are created by the ats