### PR TITLE
fix: move the theme compilation into the StorefrontPage fixture

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  timeout: 60000,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : 1,
   reporter: process.env.CI ? [

--- a/src/fixtures/DefaultSalesChannel.ts
+++ b/src/fixtures/DefaultSalesChannel.ts
@@ -12,7 +12,6 @@ import {
     getSnippetSetId,
     getThemeId,
 } from '../services/ShopwareDataHelpers';
-import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
 
 interface StoreBaseConfig {
     storefrontTypeId: string;
@@ -154,6 +153,8 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
                 }
             }
 
+            // await AdminApiContext.delete(`./sales-channel/${uuid}`);
+
             const syncResp = await AdminApiContext.post('./_action/sync', {
                 data: {
                     'write-sales-channel': {
@@ -266,38 +267,6 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
                 salesChannel: salesChannel.data,
                 customer: { ...customer.data, password: customerData.password },
                 url: baseUrl,
-            });
-        },
-        { scope: 'worker' },
-    ],
-
-    DefaultStorefront: [
-        async ({ browser, AdminApiContext, DefaultSalesChannel, SalesChannelBaseConfig }, use) => {
-            const { id: uuid } = DefaultSalesChannel.salesChannel;
-            const isSaasInstance = await isSaaSInstance(AdminApiContext);
-
-            const tmpContext = await browser.newContext({
-                baseURL: DefaultSalesChannel.url,
-            });
-            const tmpPage = await tmpContext.newPage();
-
-            if (!await isThemeCompiled(tmpPage)) {
-                base.slow();
-
-                await AdminApiContext.post(
-                    `./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${uuid}`
-                );
-
-                if (isSaasInstance) {
-                    while (!await isThemeCompiled(tmpPage)) {
-                        // eslint-disable-next-line playwright/no-wait-for-timeout
-                        await tmpPage.waitForTimeout(2000);
-                    }
-                }
-            }
-
-            await use({
-                ...DefaultSalesChannel,
             });
         },
         { scope: 'worker' },


### PR DESCRIPTION
Move the theme compilation into the StorefrontPage fixture. Creating temporary page objects in worker fixtures seems to not work reliably and is hard to debug.

Also change theme check to only require an AdminApiContext.