### PR TITLE
fix: return value leads to aborts of test projects

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -833,7 +833,7 @@ export class TestDataService {
      */
     async cleanUp() {
         if (!this.shouldCleanUp) {
-            return Promise.reject();
+            return null;
         }
 
         const priorityDeleteOperations: Record<string, SyncApiOperation> = {};

--- a/tests/TestDataService.spec.ts
+++ b/tests/TestDataService.spec.ts
@@ -1,9 +1,11 @@
-import { test, expect } from '../src/index';
+import { test, expect, type Product, Category, PropertyGroup, Customer, Order } from '../src/index';
 
 test('Data Service', async ({
     TestDataService,
+    AdminApiContext,
 }) => {
 
+    // Test test-data generation
     const category = await TestDataService.createCategory({ name: 'Custom Category' });
     expect(category.name).toEqual('Custom Category');
 
@@ -29,10 +31,45 @@ test('Data Service', async ({
     expect(order.orderCustomer.firstName).toEqual('Luke');
     expect(order.price.totalPrice).toEqual(58.99);
 
-    // Data Clean-Up
+    // Test data clean-up with deactivated cleansing process
+    TestDataService.setCleanUp(false);
+    const cleanUpFalseResponse = await TestDataService.cleanUp();
+    expect(cleanUpFalseResponse).toBeNull();
+
+    const categoryResponse = await AdminApiContext.get(`./category/${category.id}?_response=detail`);
+    const { data: databaseCategory } = (await categoryResponse.json()) as { data: Category };
+    expect(databaseCategory.id).toBe(category.id);
+
+    const productResponse = await AdminApiContext.get(`./product/${product.id}?_response=detail`);
+    const { data: databaseProduct } = (await productResponse.json()) as { data: Product };
+    expect(databaseProduct.id).toBe(product.id);
+
+    const digitalProductResponse = await AdminApiContext.get(`./product/${digitalProduct.id}?_response=detail`);
+    const { data: databaseDigitalProduct } = (await digitalProductResponse.json()) as { data: Product };
+    expect(databaseDigitalProduct.id).toBe(digitalProduct.id);
+
+    const propertyGroupResponse = await AdminApiContext.get(`./property-group/${propertyGroup.id}?_response=detail`);
+    const { data: databasePropertyGroup } = (await propertyGroupResponse.json()) as { data: PropertyGroup };
+    expect(databasePropertyGroup.id).toBe(propertyGroup.id);
+
+    const customerResponse = await AdminApiContext.get(`./customer/${customer.id}?_response=detail`);
+    const { data: databaseCustomer } = (await customerResponse.json()) as { data: Customer };
+    expect(databaseCustomer.id).toBe(customer.id);
+
+    const orderResponse = await AdminApiContext.get(`./order/${order.id}?_response=detail`);
+    const { data: databaseOrder } = (await orderResponse.json()) as { data: Order };
+    expect(databaseOrder.id).toBe(order.id);
+
+    // Test data clean-up with activated cleansing process
+    TestDataService.setCleanUp(true);
     const cleanUpResponse = await TestDataService.cleanUp();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     expect(cleanUpResponse.ok()).toBeTruthy();
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     const cleanUp = await cleanUpResponse.json();
     expect(cleanUp['notFound'].length).toBe(0);
     expect(cleanUp['deleted']['category']).toBeDefined();


### PR DESCRIPTION
If a user deactivates the cleansing process of TestData while using a project structure within playwright, the `global.setup.ts` (within that generated test data with `TestDataService`) creates an error and all further tests within different projects will be skipped.

**Steps to reproduce:**

1. Build a setup like recommended for global test data ([here](https://playwright.dev/docs/test-global-setup-teardown#option-1-project-dependencies))
2. Generate test data with `TestDataService` within `global.setup.ts`
3. Make sure to set `TestDataService.setCleanUp(false);` within `global.setup.ts`
4. run the test `xyz.spec.ts`