### PR TITLE
feat: admin - Hide symfony toolbar on page reload

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -72,6 +72,23 @@ export const test = base.extend<FixtureTypes>({
         // wait for all plugin js to be loaded
         await Promise.all(jsLoadingPromises);
 
+        // Override page reload to also remove the Symfony toolbar
+        const originalReload = page.reload.bind(page);
+        page.reload = async () => {
+            const res = await originalReload();
+            await page.addStyleTag({
+                content: `
+                .sf-toolbar {
+                    width: 0 !important;
+                    height: 0 !important;
+                    display: none !important;
+                    pointer-events: none !important;
+                }
+                `.trim(),
+            });
+            return res;
+        };
+
         // Run the test
         await use(page);
 


### PR DESCRIPTION
When calling the page.reload() method on an admin Page the Symfony toolbar is visible again, due to the styles being reset.

We should add the styles again, when we reload the page.

With this change we add the hiding of the toolbar when reloading.