### PR TITLE
feat: Add feature service

### DIFF
--- a/src/fixtures/Feature.ts
+++ b/src/fixtures/Feature.ts
@@ -1,0 +1,18 @@
+import { test as base } from '@playwright/test';
+import { FeatureService } from '../services/FeatureService';
+import { FixtureTypes } from '../types/FixtureTypes';
+
+
+export interface FeatureFixtureTypes {
+    FeatureService: FeatureService;
+}
+
+export const test = base.extend<FixtureTypes>({
+    FeatureService: async ({ AdminApiContext }, use) => {
+        const service = new FeatureService(AdminApiContext);
+
+        await use(service);
+
+        await service.cleanup();
+    },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { test as AdministrationPages } from './page-objects/AdministrationPages'
 import { test as DataFixtures } from './data-fixtures/DataFixtures';
 import { test as ShopAdminTasks } from './tasks/shop-admin-tasks';
 import { test as ShopCustomerTasks } from './tasks/shop-customer-tasks';
+import { test as FeatureService } from './fixtures/Feature';
 
 export * from '@playwright/test';
 export * from './services/ShopwareDataHelpers';
@@ -32,6 +33,7 @@ export const test = mergeTests(
     PageContexts,
     Actors,
     TestData,
+    FeatureService,
     StorefrontPages,
     AdministrationPages,
     DataFixtures,

--- a/src/services/FeatureService.ts
+++ b/src/services/FeatureService.ts
@@ -1,0 +1,131 @@
+import { AdminApiContext } from './AdminApiContext';
+
+interface FeatureFlag {
+    default: boolean;
+    major: boolean;
+    toggleable: boolean;
+    description: string;
+    active: boolean;
+}
+
+/**
+ * Service to interact with feature flags
+ */
+export class FeatureService {
+
+    private readonly apiContext: AdminApiContext;
+    private features: Record<string, FeatureFlag> = {};
+    private resetFeatures: Record<string, boolean> = {};
+
+    constructor(apiContext: AdminApiContext) {
+        this.apiContext = apiContext;
+    }
+
+    public async enable(name: string | string[]): Promise<void> {
+        if (Array.isArray(name)) {
+            for (const n of name) {
+                await this.enable(n);
+            }
+            return;
+        }
+
+        await this.loadFeatures();
+
+        if (!this.features[name]) {
+            throw new Error(`Feature flag ${name} does not exist`);
+        }
+
+        if (this.features[name].active) {
+            return;
+        }
+
+        if (!this.features[name].toggleable) {
+            throw new Error(`Feature flag ${name} is not toggleable`);
+        }
+
+        const req = await this.apiContext.post(`_action/feature-flag/enable/${name}`);
+
+        if (!req.ok()) {
+            throw new Error(`Could not enable feature flag ${name}`);
+        }
+
+        this.features[name].active = true;
+
+        // We store the reset value of the feature flag
+        if (this.resetFeatures[name] === undefined) {
+            this.resetFeatures[name] = false;
+        } else {
+            // If the feature flag was reset, we don't need to reset it again
+            delete this.resetFeatures[name];
+        }
+    }
+
+    public async disable(name: string | string[]): Promise<void> {
+        if (Array.isArray(name)) {
+            for (const n of name) {
+                await this.disable(n);
+            }
+            return;
+        }
+
+        await this.loadFeatures();
+
+        if (!this.features[name]) {
+            throw new Error(`Feature flag ${name} does not exist`);
+        }
+
+        if (!this.features[name].active) {
+            return;
+        }
+
+        if (!this.features[name].toggleable) {
+            throw new Error(`Feature flag ${name} is not toggleable`);
+        }
+
+        const req = await this.apiContext.post(`_action/feature-flag/disable/${name}`);
+
+        if (!req.ok()) {
+            throw new Error(`Could not disable feature flag ${name}`);
+        }
+
+        this.features[name].active = false;
+
+        // We store the reset value of the feature flag
+        if (this.resetFeatures[name] === undefined) {
+            this.resetFeatures[name] = true;
+        } else {
+            // If the feature flag was reset, we don't need to reset it again
+            delete this.resetFeatures[name];
+        }
+    }
+
+    public async isEnabled(name: string): Promise<boolean> {
+        await this.loadFeatures();
+
+        return this.features[name]?.active ?? false;
+    }
+
+    private async loadFeatures(): Promise<void> {
+        if (Object.keys(this.features).length >= 0) {
+            return;
+        }
+
+        const res = await this.apiContext.get('_action/feature-flag');
+
+        if (!res.ok()) {
+            throw new Error('Could not load feature flags');
+        }
+
+        this.features = await res.json();
+    }
+
+    public async cleanup(): Promise<void> {
+        for (const [name, reset] of Object.entries(this.resetFeatures)) {
+            if (reset) {
+                await this.enable(name);
+            } else {
+                await this.disable(name);
+            }
+        }
+    }
+}

--- a/src/types/FixtureTypes.ts
+++ b/src/types/FixtureTypes.ts
@@ -7,6 +7,7 @@ import { DefaultSalesChannelTypes } from '../fixtures/DefaultSalesChannel';
 import { StorefrontPageTypes } from '../page-objects/StorefrontPages';
 import { AdministrationPageTypes } from '../page-objects/AdministrationPages';
 import { DataFixtureTypes } from '../data-fixtures/DataFixtures';
+import { FeatureFixtureTypes } from '../fixtures/Feature';
 
 export interface FixtureTypes extends
     ApiContextTypes,
@@ -14,6 +15,7 @@ export interface FixtureTypes extends
     ActorFixtureTypes,
     TestDataFixtureTypes,
     HelperFixtureTypes,
+    FeatureFixtureTypes,
     DefaultSalesChannelTypes,
     StorefrontPageTypes,
     AdministrationPageTypes,


### PR DESCRIPTION
We should add a feature service to interact with feature flags. 

You can enable feature flags using: `await FeatureService.enable('FLAG');` The feature will be disabled right after the test.

This is useful for features brought in Insider-Previews to enable them while testing.