### PR TITLE
chore(ci): add 6.5.x to compose and ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,20 @@ jobs:
     test:
       timeout-minutes: 15
       runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          instance:
+            - compose-service: shopware
+              APP_URL: http://localhost:8011
+            - compose-service: shopware-65
+              APP_URL: http://localhost:8021
+      env:
+        APP_URL: ${{ matrix.instance.APP_URL }}
       steps:
       - uses: actions/checkout@v4
+      - name: Compose up ${{ matrix.instance.compose-service }} 
+        run: docker compose up -d --pull=always --quiet-pull ${{ matrix.instance.compose-service }} 
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -48,13 +60,11 @@ jobs:
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Run Playwright tests
-        run: |
-          echo $APP_URL
-          npx playwright test --repeat-each 4
+      - name: Run Playwright tests ${{ matrix.instance.compose-service }} 
+        run: npx playwright test --repeat-each 4
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.instance.compose-service }} 
           path: test-results/
           retention-days: 7

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,28 +1,48 @@
+x-env: &env
+    APP_ENV: prod
+    APP_DEBUG: 1
+    PROJECT_ROOT: /var/www/html
+    MYSQL_ROOT_PASSWORD: app
+    MYSQL_DATABASE: shopware
+    ADMINER_DEFAULT_SERVER: database
+    SHOPWARE_HTTP_CACHE_ENABLED: 0
+    DATABASE_URL: mysql://root:app@database:3306/shopware
+    APP_SECRET: secret
+    APP_URL: http://localhost:8011
+    MAILER_DSN: smtp://mailpit:1025
+    MAILPIT_BASE_URL: http://localhost:8013
+    # TEST_WEB_INSTALLER: 1
+    # SHOPWARE_SKIP_WEBINSTALLER: 0
+    # SHOPWARE_DISABLE_UPDATE_CHECK: '0'
+    # SW_RECOVERY_NEXT_VERSION: 6.6.9999999.9999999
+    # SW_RECOVERY_NEXT_BRANCH: dev-trunk
+    # SW_RECOVERY_REPOSITORY: '{"type": "path", "url": "custom/packages/*", "options": { "symlink": true } }'
+    INSTALL_LOCALE: en-US
+    INSTALL_CURRENCY: USD
+    PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
+
 x-service: &service
     environment:
-        APP_ENV: prod
-        APP_DEBUG: 1
-        PROJECT_ROOT: /var/www/html
-        MYSQL_ROOT_PASSWORD: app
-        MYSQL_DATABASE: root
-        ADMINER_DEFAULT_SERVER: database
-        SHOPWARE_HTTP_CACHE_ENABLED: 0
-        DATABASE_URL: mysql://root:app@database:3306/install_test
-        APP_SECRET: secret
-        APP_URL: http://localhost:8011
-        MAILER_DSN: smtp://mailpit:1025
-        MAILPIT_BASE_URL: http://localhost:8013
-        # TEST_WEB_INSTALLER: 1
-        # SHOPWARE_SKIP_WEBINSTALLER: 0
-        # SHOPWARE_DISABLE_UPDATE_CHECK: '0'
-        # SW_RECOVERY_NEXT_VERSION: 6.6.9999999.9999999
-        # SW_RECOVERY_NEXT_BRANCH: dev-trunk
-        # SW_RECOVERY_REPOSITORY: '{"type": "path", "url": "custom/packages/*", "options": { "symlink": true } }'
-        INSTALL_LOCALE: en-US
-        INSTALL_CURRENCY: USD
-        PHP_OPCACHE_VALIDATE_TIMESTAMPS: 1
+        <<: *env
     networks:
         - local
+
+x-shopware: &shopware-65
+    environment:
+        <<: *env
+        DATABASE_URL: mysql://root:app@database:3306/shopware_65
+        MYSQL_DATABASE: shopware_65
+        APP_URL: http://localhost:8021
+    networks:
+        - local
+    image: ghcr.io/shopware/shopware/ci-e2e:v6.5.x
+    volumes:
+    - jwt:/var/www/html/config/jwt
+    - media:/var/www/html/public/media
+    - theme:/var/www/html/public/theme
+    - bundles:/var/www/html/public/bundles
+    - thumbnail:/var/www/html/public/thumbnail
+    - cache:/var/www/html/var/cache
 
 services:
     database:
@@ -49,17 +69,34 @@ services:
         image: axllent/mailpit
         ports:
             - 8013:8025
-
     shopware:
         <<: *service
-        # TODO: build trunk tag
         image: ghcr.io/shopware/shopware/ci-e2e:trunk
         depends_on: [ database, mailpit ]
         ports:
             - '8011:8000'
-        # mount platform
-        # volumes:
-        # - ../../:/var/www/html/custom/platform
+
+    init-65:
+        <<: *shopware-65
+        depends_on: [ database, mailpit ]
+        entrypoint: ['sh', '/init.sh']
+        user: root
+
+    shopware-65:
+        <<: *shopware-65
+        depends_on:
+            init-65:
+                condition: service_completed_successfully
+        ports:
+            - '8021:8000'
+
+volumes:
+  jwt:
+  media:
+  theme:
+  bundles:
+  thumbnail:
+  cache:
 
 networks:
     local:


### PR DESCRIPTION
This PR adds a job to also test against a shopware 6.5 instance.

By default, the local setup will still only test trunk.

If you want to test 6.5, you have to do this:
```bash
docker compose up -d shopware-65
APP_URL=http://localhost:8021 npx playwright test
```