### PR TITLE
Change AccountOrder orderExpandButton to locator

### DIFF
--- a/src/page-objects/storefront/AccountOrder.ts
+++ b/src/page-objects/storefront/AccountOrder.ts
@@ -8,7 +8,7 @@ export class AccountOrder implements PageObject {
     public readonly digitalProductDownloadButton: Locator;
 
     constructor(public readonly page: Page) {
-        this.orderExpandButton = page.locator('.order-hide-btn').first();
+        this.orderExpandButton = page.getByRole('button', {name: /Expand|Show details/}).first();
         this.cartLineItemImages = page.locator('.line-item-img-link');
         this.digitalProductDownloadButton = page.getByRole('link', { name: 'Download' }).first();
     }

--- a/src/page-objects/storefront/AccountOrder.ts
+++ b/src/page-objects/storefront/AccountOrder.ts
@@ -8,7 +8,7 @@ export class AccountOrder implements PageObject {
     public readonly digitalProductDownloadButton: Locator;
 
     constructor(public readonly page: Page) {
-        this.orderExpandButton = page.getByRole('button', {name: 'Expand'}).first();
+        this.orderExpandButton = page.locator('.order-hide-btn').first();
         this.cartLineItemImages = page.locator('.line-item-img-link');
         this.digitalProductDownloadButton = page.getByRole('link', { name: 'Download' }).first();
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fdb07175-1dc0-4f64-b8c9-b5d9b1338dda)


For accessibility improvements we want to change the translation from generic "Expand" wording to "Show details" or "Hide details".

To make it still work in older versions that don't have the updated snippet, use a class selector instead of text.