### PR TITLE
feat: redefine page and context from AdminPage

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -1,4 +1,4 @@
-import { test as base, expect, Page } from '@playwright/test';
+import { test as base, expect, Page, BrowserContext } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import { mockApiCalls } from '../services/ApiMocks';
 import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
@@ -6,6 +6,8 @@ import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
 export interface PageContextTypes {
     AdminPage: Page;
     StorefrontPage: Page;
+    page: Page;
+    context: BrowserContext;
 }
 
 export const test = base.extend<FixtureTypes>({
@@ -130,5 +132,13 @@ export const test = base.extend<FixtureTypes>({
 
         await page.close();
         await context.close();
+    },
+
+    page: async ({ AdminPage }, use) => {
+        await use(AdminPage);
+    },
+
+    context: async ({ AdminPage }, use) => {
+        await use(AdminPage.context());
     },
 });

--- a/tests/PageObjects.spec.ts
+++ b/tests/PageObjects.spec.ts
@@ -1,4 +1,4 @@
-import { test, getFlowId, isSaaSInstance } from '../src/index';
+import { test, getFlowId, isSaaSInstance, expect } from '../src/index';
 
 test('Storefront page objects.', async ({
     ShopCustomer,
@@ -116,4 +116,16 @@ test('Administration page objects.', async ({
             await ShopAdmin.expects(AdminDataSharing.dataConsentHeadline).toBeVisible();
         }
     }
+});
+
+test('page is the same as AdminPage', async ({
+    page, AdminPage,
+}) => {
+    expect(page).toBe(AdminPage);
+});
+
+test('context is the same as AdminPage.context()', async ({
+    context, AdminPage,
+}) => {
+    expect(context).toBe(AdminPage.context());
 });


### PR DESCRIPTION
The `page` and `context` fixtures are provided by playwright.

Right now they are fresh objects that are unrelated to the ATS fixture `AdminPage`. This causes some issue if you use the page or context object in your tests because you might expect them to be the same. For example when waiting for page events.

To solve this we redefine them as being the `AdminPage` and `AdminPage.context()` respectively.