### PR TITLE
Wrong page context during the installation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "3.11.1",
+  "version": "3.11.0",
   "description": "Shopware Acceptance Test Suite",
   "author": "shopware AG",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Shopware Acceptance Test Suite",
   "author": "shopware AG",
   "license": "MIT",

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -135,15 +135,12 @@ export const test = base.extend<FixtureTypes>({
         await context.close();
     },
 
-    InstallPage: async ({ DefaultSalesChannel, browser }, use) => {
-        const { url } = DefaultSalesChannel;
+    InstallPage: async ({ browser }, use) => {
 
         const context = await browser.newContext({
-            baseURL: url,
+            baseURL: process.env['APP_URL'],
         });
         const page = await context.newPage();
-
-        await page.goto(url, { waitUntil: 'load' });
 
         await use(page);
 

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -6,6 +6,7 @@ import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
 export interface PageContextTypes {
     AdminPage: Page;
     StorefrontPage: Page;
+    InstallPage: Page;
     page: Page;
     context: BrowserContext;
 }
@@ -127,6 +128,22 @@ export const test = base.extend<FixtureTypes>({
         }
 
         await page.goto('./', { waitUntil: 'load' });
+
+        await use(page);
+
+        await page.close();
+        await context.close();
+    },
+
+    InstallPage: async ({ DefaultSalesChannel, browser }, use) => {
+        const { url } = DefaultSalesChannel;
+
+        const context = await browser.newContext({
+            baseURL: url,
+        });
+        const page = await context.newPage();
+
+        await page.goto(url, { waitUntil: 'load' });
 
         await use(page);
 


### PR DESCRIPTION
With version 3.9.0, an introduction to make the page and context fixtures more robust was made. That led to an issue where the shopware installation process worked in the wrong page context.

The solution is to introduce a new page context with a plane environment. 