### PR TITLE
fix: missing installer page context for installer test

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -6,6 +6,7 @@ import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
 export interface PageContextTypes {
     AdminPage: Page;
     StorefrontPage: Page;
+    InstallPage: Page;
     page: Page;
     context: BrowserContext;
 }
@@ -127,6 +128,19 @@ export const test = base.extend<FixtureTypes>({
         }
 
         await page.goto('./', { waitUntil: 'load' });
+
+        await use(page);
+
+        await page.close();
+        await context.close();
+    },
+
+    InstallPage: async ({ browser }, use) => {
+
+        const context = await browser.newContext({
+            baseURL: process.env['APP_URL'],
+        });
+        const page = await context.newPage();
 
         await use(page);
 


### PR DESCRIPTION
With version 3.9.0, an introduction to make the page and context fixtures more robust was made. That led to an issue where the shopware installation process worked in the wrong page context.

The solution is to introduce a new page context with a plane environment.