### PR TITLE
feat: add create currency to TestDataService

### DIFF
--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -6,6 +6,7 @@ export class CheckoutConfirm implements PageObject {
     public readonly termsAndConditionsCheckbox: Locator;
     public readonly immediateAccessToDigitalProductCheckbox: Locator;
     public readonly grandTotalPrice: Locator;
+    public readonly taxPrice: Locator;
     public readonly submitOrderButton: Locator;
 
     /**
@@ -31,6 +32,7 @@ export class CheckoutConfirm implements PageObject {
         this.termsAndConditionsCheckbox = page.getByLabel('I have read and accepted the general terms and conditions.');
         this.immediateAccessToDigitalProductCheckbox = page.getByLabel('I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel.');
         this.grandTotalPrice = page.locator(`dt:has-text('Grand total') + dd`);
+        this.taxPrice = page.locator(`dt:text-matches('plus [0-9]\\+\\?% VAT') + dd`);
         this.submitOrderButton = page.getByRole('button', { name: 'Submit order' });
 
         this.paymentCashOnDelivery = page.getByLabel('Cash on delivery');

--- a/src/page-objects/storefront/CheckoutFinish.ts
+++ b/src/page-objects/storefront/CheckoutFinish.ts
@@ -5,6 +5,7 @@ export class CheckoutFinish implements PageObject {
     public readonly headline: Locator;
     public readonly orderNumberText: Locator;
     public readonly grandTotalPrice: Locator;
+    public readonly taxPrice: Locator;
     public readonly cartLineItemImages: Locator;
 
     private readonly orderNumberRegex = /Your order number: #(\d+)/;
@@ -13,6 +14,7 @@ export class CheckoutFinish implements PageObject {
         this.headline = page.getByRole('heading', { name: 'Thank you for your order' });
         this.orderNumberText = page.getByText(this.orderNumberRegex);
         this.grandTotalPrice = page.locator('dt:has-text("Grand total") + dd');
+        this.taxPrice = page.locator(`dt:text-matches('plus [0-9]\\+\\?% VAT') + dd`);
         this.cartLineItemImages = page.locator('.line-item-img-link');
     }
 

--- a/src/page-objects/storefront/Home.ts
+++ b/src/page-objects/storefront/Home.ts
@@ -5,10 +5,39 @@ export class Home implements PageObject {
 
     public readonly productImages: Locator;
     public readonly productListItems: Locator;
+    public readonly languagesDropdown: Locator;
+    public readonly currenciesDropdown: Locator;
 
     constructor(public readonly page: Page) {
         this.productImages = page.locator('.product-image-link');
         this.productListItems = page.getByRole('listitem');
+        this.languagesDropdown = page.getByLabel('Shop settings').locator('.languages-menu');
+        this.currenciesDropdown = page.getByLabel('Shop settings').locator('.currencies-menu');
+    }
+
+    async getListingItemByProductId(productId: string): Promise<Record<string, Locator>> {
+        const listingItem = this.page.getByRole('listitem').filter({ has: this.page.locator(`[value="${productId}"]`) });
+        const productImage = listingItem.locator('.product-image-link');
+        const productRating = listingItem.locator('.product-rating');
+        const productVariantCharacteristics = listingItem.locator('.product-variant-characteristics');
+        const productDescription = listingItem.locator('.product-description');
+        const productPriceUnit = listingItem.locator('.product-price-unit');
+        const productCheapestPrice = listingItem.locator('.product-cheapest-price');
+        const productPrice = listingItem.locator('.product-price');
+        const productName = listingItem.locator('.product-name');
+        const productAddToShoppingCart = listingItem.getByRole('button', { name: 'Add to shopping cart' });
+
+        return {
+            productImage: productImage,
+            productRating: productRating,
+            productVariantCharacteristics: productVariantCharacteristics,
+            productDescription: productDescription,
+            productPriceUnit: productPriceUnit,
+            productCheapestPrice: productCheapestPrice,
+            productPrice: productPrice,
+            productName: productName,
+            productAddToShoppingCart: productAddToShoppingCart,
+        }
     }
 
     url() {

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -25,6 +25,7 @@ import type {
     PropertyGroupOption,
     DeliveryTime,
     CmsPage,
+    Country,
 } from '../types/ShopwareTypes';
 import { expect } from '@playwright/test';
 
@@ -779,6 +780,52 @@ export class TestDataService {
     }
 
     /**
+     * Creates a random country
+     *
+     * @param overrides - Specific data overrides that will be applied to the country data struct.
+     */
+    async createCountry(
+        overrides: Partial<Country> = {},
+    ): Promise<Country> {
+        const basicCountry = this.getCountryStruct(overrides);
+
+        const countryResponse = await this.AdminApiClient.post('country?_response=detail', {
+            data: basicCountry,
+        });
+        expect(countryResponse.ok()).toBeTruthy();
+
+        const { data: country } = (await countryResponse.json()) as { data: Country };
+
+        this.addCreatedRecord('country', country.id);
+
+        return country;
+    }
+
+    /**
+     * Creates a random currency with default rounding of 2 decimals
+     *
+     * @param roundingDecimals - Decimals of the rounding shown in Storefront, default value 2
+     * @param overrides - Specific data overrides that will be applied to the currency data struct.
+     */
+    async createCurrency(
+        overrides: Partial<Currency> = {},
+        roundingDecimals = 2,
+    ): Promise<Currency> {
+        const basicCurrency = this.getCurrencyStruct(overrides, roundingDecimals);
+
+        const currencyResponse = await this.AdminApiClient.post('currency?_response=detail', {
+            data: basicCurrency,
+        });
+        expect(currencyResponse.ok()).toBeTruthy();
+
+        const { data: currency } = (await currencyResponse.json()) as { data: Currency };
+
+        this.addCreatedRecord('currency', currency.id);
+
+        return currency;
+    }
+
+    /**
      * Assigns a media resource as the download of a digital product.
      *
      * @param productId - The uuid of the product.
@@ -841,6 +888,48 @@ export class TestDataService {
                 manufacturerId: manufacturerId,
             },
         });
+    }
+
+    /**
+     * Assigns a country to a currency with default roundings of 2.
+     *
+     * @param currencyId - The uuid of currency.
+     * @param countryId - The uuid of country.
+     * @param roundingDecimals - The roundings of item and total values in storefront, default 2 decimals
+     */
+    async assignCurrencyCountryRounding(currencyId: string, countryId: string, roundingDecimals = 2) {
+
+        const syncCurrencyCountryRoundingResponse = await this.AdminApiClient.post('./_action/sync', {
+            data: {
+                'write-currency-country-rounding': {
+                    entity: 'currency_country_rounding',
+                    action: 'upsert',
+                    payload: [
+                        {
+                            id: this.IdProvider.getIdPair().uuid,
+                            currencyId: currencyId,
+                            countryId: countryId,
+                            itemRounding: {
+                                decimals: roundingDecimals,
+                                interval: 0.01,
+                                roundForNet: true,
+                            },
+                            totalRounding: {
+                                decimals: roundingDecimals,
+                                interval: 0.01,
+                                roundForNet: true,
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+        expect(syncCurrencyCountryRoundingResponse.ok()).toBeTruthy();
+
+        const { data: currencyCountry } = await syncCurrencyCountryRoundingResponse.json();
+
+        return currencyCountry;
+
     }
 
     /**
@@ -907,6 +996,64 @@ export class TestDataService {
      */
     async assignManufacturerProduct(manufacturerId: string, productId: string) {
         await this.assignProductManufacturer(productId, manufacturerId);
+    }
+
+    /**
+     * Assigns a currency to a sales channel.
+     *
+     * @param salesChannelId - The uuid of the sales channel.
+     * @param currencyId - The uuid of the currency.
+     */
+    async assignSalesChannelCurrency(salesChannelId: string, currencyId: string) {
+
+        const syncSalesChannelResponse = await this.AdminApiClient.post('./_action/sync', {
+            data: {
+                'write-sales-channel': {
+                    entity: 'sales_channel',
+                    action: 'upsert',
+                    payload: [
+                        {
+                            id: salesChannelId,
+                            currencies: [{ id: currencyId }],
+                        },
+                    ],
+                },
+            },
+        });
+        expect(syncSalesChannelResponse.ok()).toBeTruthy();
+
+        const { data: salesChannel } = await syncSalesChannelResponse.json();
+
+        return salesChannel;
+    }
+
+    /**
+     * Assigns a country to a sales channel.
+     *
+     * @param salesChannelId - The uuid of the sales channel.
+     * @param countryId - The uuid of the country.
+     */
+    async assignSalesChannelCountry(salesChannelId: string, countryId: string) {
+
+        const syncSalesChannelResponse = await this.AdminApiClient.post('./_action/sync', {
+            data: {
+                'write-sales-channel': {
+                    entity: 'sales_channel',
+                    action: 'upsert',
+                    payload: [
+                        {
+                            id: salesChannelId,
+                            countries: [{ id: countryId }],
+                        },
+                    ],
+                },
+            },
+        });
+        expect(syncSalesChannelResponse.ok()).toBeTruthy();
+
+        const { data: salesChannel } = await syncSalesChannelResponse.json();
+
+        return salesChannel;
     }
 
     /**
@@ -1303,6 +1450,76 @@ export class TestDataService {
         helper([], 0);
         return result;
     };
+
+    /**
+     * Retrieves a country Id based on its iso2 code.
+     *
+     * @param iso2 - The iso2 code of the country, for example "DE".
+     */
+    async getCountryId(iso2: string): Promise<Country> {
+        const countryResponse = await this.AdminApiClient.post('search/country', {
+            data: {
+                limit: 1,
+                filter: [{
+                    type: 'equals',
+                    field: 'iso',
+                    value: iso2,
+                }],
+            },
+        });
+
+        const { data: result } = (await countryResponse.json()) as { data: Country[] };
+
+        return result[0];
+    }
+
+    getCountryStruct(
+        overrides: Partial<Country> = {},
+    ): Partial<Country> {
+
+        const { uuid: countryUuid, id: countryId } = this.IdProvider.getIdPair();
+
+        const basicCountry = {
+            id: countryUuid,
+            name: 'Country-'+countryId,
+            iso: ''+countryId.substring(0,2),
+            iso3: ''+countryId.substring(0,3),
+            active: true,
+            shippingAvailable: true,
+        };
+
+        return Object.assign({}, basicCountry, overrides);
+    }
+
+    getCurrencyStruct(
+        overrides: Partial<Currency> = {},
+        roundingDecimals: number,
+    ): Partial<Currency> {
+
+        const { uuid: currencyUuid, id: currencyId } = this.IdProvider.getIdPair();
+
+        const basicCurrency = {
+            id: currencyUuid,
+            name: 'Currency-'+currencyId,
+            shortName: 'CUR'+currencyId,
+            isoCode: ''+currencyId.substring(0,3),
+            symbol: 'C$',
+            factor: 2.40,
+            itemRounding: {
+                decimals: roundingDecimals,
+                interval: 0.01,
+                roundForNet: true,
+            },
+            totalRounding: {
+                decimals: roundingDecimals,
+                interval: 0.01,
+                roundForNet: true,
+            },
+            taxFreeFrom: 0,
+        };
+
+        return Object.assign({}, basicCurrency, overrides);
+    }
 
     getBasicProductStruct(
         taxId = this.defaultTaxId,

--- a/src/tasks/shop-customer-tasks.ts
+++ b/src/tasks/shop-customer-tasks.ts
@@ -3,6 +3,9 @@ import { mergeTests } from '@playwright/test';
 import { Login } from './shop-customer/Account/Login';
 import { Logout } from './shop-customer/Account/Logout';
 import { Register } from './shop-customer/Account/Register';
+import { RegisterGuest } from './shop-customer/Account/RegisterGuest';
+import { ChangeStorefrontCurrency } from './shop-customer/Account/ChangeStorefrontCurrency';
+
 
 import { AddProductToCart } from './shop-customer/Product/AddProductToCart';
 import { ProceedFromProductToCheckout } from './shop-customer/Product/ProceedFromProductToCheckout';
@@ -26,6 +29,8 @@ export const test = mergeTests(
     Login,
     Logout,
     Register,
+    RegisterGuest,
+    ChangeStorefrontCurrency,
     AddProductToCart,
     ChangeProductQuantity,
     ProceedFromProductToCheckout,

--- a/src/tasks/shop-customer/Account/ChangeStorefrontCurrency.ts
+++ b/src/tasks/shop-customer/Account/ChangeStorefrontCurrency.ts
@@ -1,0 +1,16 @@
+import { test as base } from '@playwright/test';
+import type { Task } from '../../../types/Task';
+import type { FixtureTypes} from '../../../types/FixtureTypes';
+export const ChangeStorefrontCurrency = base.extend<{ ChangeStorefrontCurrency: Task }, FixtureTypes>({
+    ChangeStorefrontCurrency: async ({ StorefrontHome }, use) => {
+        const task = (isoCode: string) => {
+            return async function ChangeStorefrontCurrency() {
+                await StorefrontHome.currenciesDropdown.click();
+                await StorefrontHome.currenciesDropdown.getByText(' '+isoCode).click();
+
+            }
+        };
+
+        await use(task);
+    },
+});

--- a/src/tasks/shop-customer/Account/RegisterGuest.ts
+++ b/src/tasks/shop-customer/Account/RegisterGuest.ts
@@ -1,0 +1,65 @@
+import { test as base, expect } from '@playwright/test';
+import type { Task } from '../../../types/Task';
+import type { FixtureTypes} from '../../../types/FixtureTypes';
+import type { components } from '@shopware/api-client/admin-api-types';
+
+export const RegisterGuest = base.extend<{ RegisterGuest: Task }, FixtureTypes>({
+    RegisterGuest: async ({ StorefrontAccountLogin, AdminApiContext }, use) => {
+
+        const registrationData = {
+            firstName: 'Jeff',
+            lastName: 'Goldblum',
+            email: 'invalid',
+            password: 'shopware',
+            street: 'Ebbinghof 10',
+            city: 'Schöppingen',
+            country: 'Germany',
+            postalCode: '48624',
+        }
+
+        const task = (email: string, country = 'Germany') => {
+            return async function RegisterGuest() {
+
+                registrationData.email = email;
+
+                await StorefrontAccountLogin.firstNameInput.fill(registrationData.firstName);
+                await StorefrontAccountLogin.lastNameInput.fill(registrationData.lastName);
+
+                await StorefrontAccountLogin.registerEmailInput.fill(registrationData.email);
+
+                await StorefrontAccountLogin.streetAddressInput.fill(registrationData.street);
+                await StorefrontAccountLogin.cityInput.fill(registrationData.city);
+                if(country != 'Germany') {
+                    await StorefrontAccountLogin.countryInput.selectOption(country);
+
+                } else {
+                    await StorefrontAccountLogin.countryInput.selectOption(registrationData.country);
+
+                }
+                await StorefrontAccountLogin.postalCodeInput.fill(registrationData.postalCode);
+
+                await StorefrontAccountLogin.registerButton.click();
+            }
+        };
+
+        await use(task);
+
+        const customerResponse = await AdminApiContext.post('search/customer', {
+            data: {
+                limit: 1,
+                filter: [{
+                    type: 'equals',
+                    field: 'email',
+                    value: registrationData.email,
+                }],
+            },
+        });
+        expect(customerResponse.ok()).toBeTruthy();
+
+        const customerResponseData = await customerResponse.json() as { data: components['schemas']['Customer'][] };
+
+        for (const customer of customerResponseData.data) {
+            await AdminApiContext.delete(`customer/${customer.id}`);
+        }
+    },
+});

--- a/src/types/ShopwareTypes.ts
+++ b/src/types/ShopwareTypes.ts
@@ -4,9 +4,27 @@ export type SalesChannel = components['schemas']['SalesChannel'] & {
     id: string,
 }
 
-export type Customer = components['schemas']['Customer'] & {
+export type Customer = Omit<components['schemas']['Customer'], 'defaultShippingAddress' | 'defaultBillingAddress'> & {
     id: string,
     password: string,
+    defaultShippingAddress: {
+        firstName: string,
+        lastName: string,
+        city: string,
+        street: string,
+        zipcode: string,
+        countryId: string,
+        salutationId: string,
+    },
+    defaultBillingAddress: {
+        firstName: string,
+        lastName: string,
+        city: string,
+        street: string,
+        zipcode: string,
+        countryId: string,
+        salutationId: string,
+    }
 }
 
 export type CustomerAddress = components['schemas']['CustomerAddress'] & {
@@ -79,6 +97,10 @@ export type Rule = components['schemas']['Rule'] & {
 }
 
 export type Currency = components['schemas']['Currency'] & {
+    id: string,
+}
+
+export type Country = components['schemas']['Country'] & {
     id: string,
 }
 

--- a/tests/TestDataService/TestDataService.spec.ts
+++ b/tests/TestDataService/TestDataService.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect, type Product, Category, PropertyGroup, Customer, Manufacturer, PaymentMethod, Rule, ShippingMethod } from '../../src/index';
-
+import { test, expect, type Product, Category, PropertyGroup, Customer, Manufacturer, PaymentMethod, Rule, ShippingMethod, Currency, Country } from '../../src/index';
 
 test('Data Service', async ({
     TestDataService,
@@ -106,6 +105,12 @@ test('Data Service', async ({
     expect(cmsPage.name).toEqual(cmsPageName);
     expect(cmsPage.type).toEqual(cmsType);
 
+    const currency = await TestDataService.createCurrency({ taxFreeFrom: 10 });
+    expect(currency.taxFreeFrom).toEqual(10);
+
+    const country = await TestDataService.createCountry();
+    expect(country.name).toBeDefined();
+
     // Test data clean-up with deactivated cleansing process
     TestDataService.setCleanUp(false);
     const cleanUpFalseResponse = await TestDataService.cleanUp();
@@ -131,7 +136,6 @@ test('Data Service', async ({
     const { data: databaseCustomer } = (await customerResponse.json()) as { data: Customer };
     expect(databaseCustomer.id).toBe(customer.id);
 
-
     const manufacturerResponse = await AdminApiContext.get(`./product-manufacturer/${manufacturer.id}?_response=detail`);
     const { data: databaseManufacturer } = (await manufacturerResponse.json()) as { data: Manufacturer };
     expect(databaseManufacturer.id).toBe(manufacturer.id);
@@ -147,6 +151,14 @@ test('Data Service', async ({
     const ruleResponse = await AdminApiContext.get(`./rule/${rule.id}?_response=detail`);
     const { data: databaseRule } = (await ruleResponse.json()) as { data: Rule };
     expect(databaseRule.id).toBe(rule.id);
+
+    const currencyResponse = await AdminApiContext.get(`./currency/${currency.id}?_response=detail`);
+    const { data: databaseCurrency } = (await currencyResponse.json()) as { data: Currency };
+    expect(databaseCurrency.id).toBe(currency.id);
+
+    const countryResponse = await AdminApiContext.get(`./country/${country.id}?_response=detail`);
+    const { data: databaseCountry } = (await countryResponse.json()) as { data: Country };
+    expect(databaseCountry.id).toBe(country.id);
 
     // Test data clean-up with activated cleansing process
     TestDataService.setCleanUp(true);
@@ -170,4 +182,6 @@ test('Data Service', async ({
     expect(cleanUp['deleted']['shipping_method']).toBeDefined();
     expect(cleanUp['deleted']['rule']).toBeDefined();
     expect(cleanUp['deleted']['cms_page']).toBeDefined();
+    expect(cleanUp['deleted']['currency']).toBeDefined();
+    expect(cleanUp['deleted']['country']).toBeDefined();
 });


### PR DESCRIPTION
- Add `createCurrency()` in the TestDataService
- Add `createCountry()` in the TestDataService
- Add `assignCurrencyCountryRounding()` in the TestDataService
- Add `assignSalesChannelCurrency()` in the TestDataService
- Add `assignSalesChannelCountry()` in the TestDataService
- Add `RegsiterGuest` task
- Add `ChangeStorefrontCurrency` task
- some TestDataService refactorings