### PR TITLE
NEXT-39805 - Fix selector in VariantGeneration test

### DIFF
--- a/src/page-objects/administration/ProductDetail.ts
+++ b/src/page-objects/administration/ProductDetail.ts
@@ -66,7 +66,7 @@ export class ProductDetail implements PageObject {
         this.generateVariantsButton = page.getByRole('button', { name: 'Generate variants' });
         this.variantsModal = page.getByRole('dialog', { name: 'Generate variants' });
         this.variantsModalHeadline = this.variantsModal.getByRole('heading', { name: 'Generate variants' });
-        this.variantsNextButton = this.variantsModal.getByRole('button', { name: 'Next' });
+        this.variantsNextButton = this.variantsModal.getByRole('button', { name: 'Next', exact: true });
         this.variantsSaveButton = this.variantsModal.getByRole('button', { name: 'Save variants' });
 
         this.propertyGroupColor = this.variantsModal.getByText('Color').first();


### PR DESCRIPTION
Due the Accessibility changes, a button in pagination has the `aria-label` "Next page".

This conflicts with a selector used in the VariantGeneration tests.

The solution is adding the `exact: true` to selector to look for only for buttons with that exact text instead of any containing that text.