### PR TITLE
fix: revert 6.7 locator compatibility for customer group pages in admin

### DIFF
--- a/src/page-objects/AdministrationPages.ts
+++ b/src/page-objects/AdministrationPages.ts
@@ -126,12 +126,12 @@ export const test = base.extend<FixtureTypes>({
         await use(new CustomerGroupListing(AdminPage));
     },
 
-    AdminCustomerGroupCreate: async ({ AdminPage, InstanceMeta }, use) => {
-        await use(new CustomerGroupCreate(AdminPage, InstanceMeta));
+    AdminCustomerGroupCreate: async ({ AdminPage }, use) => {
+        await use(new CustomerGroupCreate(AdminPage));
     },
 
-    AdminCustomerGroupDetail: async ({ AdminPage, InstanceMeta }, use) => {
-        await use(new CustomerGroupDetail(AdminPage, InstanceMeta));
+    AdminCustomerGroupDetail: async ({ AdminPage }, use) => {
+        await use(new CustomerGroupDetail(AdminPage));
     },
 
     AdminFirstRunWizard: async ({ AdminPage, InstanceMeta }, use) => {

--- a/src/page-objects/administration/CustomerGroupCreate.ts
+++ b/src/page-objects/administration/CustomerGroupCreate.ts
@@ -1,7 +1,5 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
-import { satisfies } from 'compare-versions';
-import { HelperFixtureTypes } from 'src/fixtures/HelperFixtures';
 
 export class CustomerGroupCreate implements PageObject {
     public readonly headline: Locator;
@@ -19,7 +17,7 @@ export class CustomerGroupCreate implements PageObject {
     public readonly customerGroupSaleschannelSelection: Locator;
     public readonly customerGroupSaleschannelResultList: Locator;
 
-    constructor(public readonly page: Page, public readonly instanceMeta: HelperFixtureTypes['InstanceMeta']) {
+    constructor(public readonly page: Page) {
         this.headline = page.getByRole('heading', { name: 'New customer group' });
         this.saveButton = page.getByRole('button', { name: 'Save' });
         this.cancelButton = page.getByRole('button', { name: 'Cancel' });
@@ -29,11 +27,7 @@ export class CustomerGroupCreate implements PageObject {
         this.customerGroupNetTaxDisplay = page.locator('#sw-field--castedValue-1');
         this.customSignupFormToggle = page.getByLabel('Custom signup form');
         this.signupFormTitle = page.locator('#sw-field--customerGroup-registrationTitle');
-        if (satisfies(instanceMeta.version, '<6.7')) {
-            this.signupFormIntroduction = page.locator('.sw-text-editor__content-editor');
-        } else {
-            this.signupFormIntroduction = page.locator('.mt-text-editor__content-editor');
-        }
+        this.signupFormIntroduction = page.locator('.sw-text-editor__content-editor');
         this.signupFormSeoDescription = page.locator('#sw-field--customerGroup-registrationSeoMetaDescription');
         this.signupFormCompanySignupToggle = page.getByLabel('Company signup form');
         this.customerGroupSaleschannelSelection = page.locator('input[class=sw-select-selection-list__input]');

--- a/src/page-objects/administration/CustomerGroupDetail.ts
+++ b/src/page-objects/administration/CustomerGroupDetail.ts
@@ -1,16 +1,15 @@
 import type { Page, Locator } from '@playwright/test';
 import type { PageObject } from '../../types/PageObject';
 import { CustomerGroupCreate } from './CustomerGroupCreate';
-import { HelperFixtureTypes } from 'src/fixtures/HelperFixtures';
 
 export class CustomerGroupDetail extends CustomerGroupCreate implements PageObject {
     public readonly headline: Locator;
     public readonly selectedSalesChannel: Locator;
     public readonly technicalUrl: Locator;
     public readonly saleschannelUrl: Locator;
-    
-    constructor(public readonly page: Page, public readonly instanceMeta: HelperFixtureTypes['InstanceMeta']) {
-        super(page, instanceMeta);
+
+    constructor(public readonly page: Page) {
+        super(page);
         this.headline = page.locator('.smart-bar__header');
         this.selectedSalesChannel = page.locator('.sw-select-selection-list');
         this.technicalUrl = page.getByLabel('Technical URL');


### PR DESCRIPTION
`.mt-text-editor__content-editor`  locator is not available in 6.7 trunk