### PR TITLE
fix: Use string as scope

### DIFF
--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -89,7 +89,7 @@ export class AdminApiContext {
                 grant_type: 'client_credentials',
                 client_id: options.client_id,
                 client_secret: options.client_secret,
-                scope: ['write'],
+                scope: 'write',
             },
         });
 
@@ -109,7 +109,7 @@ export class AdminApiContext {
                 grant_type: 'password',
                 username: options.admin_username,
                 password: options.admin_password,
-                scope: ['write'],
+                scope: 'write',
             },
         });
 


### PR DESCRIPTION
Using a list of scopes was not spec compliant: https://github.com/thephpleague/oauth2-server/issues/1469

With an update of our oauth lib this is no longer supported, leading to fails in the ATS: https://github.com/shopware/shopware/pull/5986