### PR TITLE
Introduce ADMIN_API_URL environment variable for customizable admin API endpoint

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,9 @@ if (process.env['ADMIN_URL']) {
 } else {
   process.env['ADMIN_URL'] = process.env['APP_URL'] + 'admin/';
 }
-
+if (process.env['ADMIN_API_URL']) {
+  process.env['ADMIN_API_URL'] = (process.env['ADMIN_API_URL'] ?? '').replace(/\/+$/, '') + '/';
+}
 if (!process.env['WEBSERVER_COMMAND']) {
   if (process.env['WEBSERVER_COMMAND'] === defaultAppUrl) {
     process.env['WEBSERVER_COMMAND'] = 'docker compose up --pull=always --quiet-pull shopware';

--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -23,7 +23,7 @@ export class AdminApiContext {
     public readonly options: AdminApiContextOptions;
 
     private static readonly defaultOptions: AdminApiContextOptions = {
-        app_url: process.env['APP_URL'],
+        app_url: process.env['ADMIN_API_URL'] || process.env['APP_URL'],
         client_id: process.env['SHOPWARE_ACCESS_KEY_ID'],
         client_secret: process.env['SHOPWARE_SECRET_ACCESS_KEY'],
         admin_username: process.env['SHOPWARE_ADMIN_USERNAME'] || 'admin',

--- a/src/tasks/shop-admin/Product/SaveProduct.ts
+++ b/src/tasks/shop-admin/Product/SaveProduct.ts
@@ -10,7 +10,7 @@ export const SaveProduct = base.extend<{ SaveProduct: Task }, FixtureTypes>({
                 await AdminProductDetail.savePhysicalProductButton.click();
 
                 // Wait until product is saved via API
-                const response = await AdminProductDetail.page.waitForResponse(`${process.env['APP_URL']}api/_action/sync`);
+                const response = await AdminProductDetail.page.waitForResponse(`${process.env['ADMIN_API_URL'] || process.env['APP_URL']}api/_action/sync`);
 
                 // Assertions
                 expect(response.ok()).toBeTruthy();


### PR DESCRIPTION
**Hello!** 👋  

This PR introduces a new environment variable: **`ADMIN_API_URL`**, allowing users to define a custom endpoint for the admin API. This provides more flexibility for different deployment setups.  

### What's inside?  

- **`src/services/AdminApiContext.ts`**: Adds `ADMIN_API_URL` as the default before `APP_URL` in `AdminApiContextOptions` to allow custom admin API endpoints.  
- **`src/tasks/shop-admin/Product/SaveProduct.ts`**: Adds `ADMIN_API_URL` management here as well, since there's an API call outside `AdminApiContext`.  
