### PR TITLE
fix: remove commercial only locator method

### DIFF
--- a/src/page-objects/storefront/AccountOrder.ts
+++ b/src/page-objects/storefront/AccountOrder.ts
@@ -56,10 +56,6 @@ export class AccountOrder implements PageObject {
             totalGross: totalGross,
         }
     }
-    getViewSubscriptionLink = (orderNumber: string): Locator => {
-        const orderContainer = this.page.locator('.order-item-header', { hasText: `Order Number: ${orderNumber}`});
-        return orderContainer.getByText('View Subscription');
-    };
 
     url() {
         return 'account/order';


### PR DESCRIPTION
That method was accidentally moved to the ATS and is not relevant here because the locator method is exclusively for the commercial repository.