### PR TITLE
feat: move sales channel default data to fixtures (#305)

### DIFF
--- a/src/fixtures/DefaultSalesChannel.ts
+++ b/src/fixtures/DefaultSalesChannel.ts
@@ -2,16 +2,6 @@ import { test as base, expect } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import type { Customer, SalesChannel } from '../types/ShopwareTypes';
 import type { components } from '@shopware/api-client/admin-api-types';
-import {
-    getLanguageData,
-    getCurrency,
-    getPaymentMethodId,
-    getDefaultShippingMethodId,
-    getTaxId,
-    getCountryId,
-    getSnippetSetId,
-    getThemeId,
-} from '../services/ShopwareDataHelpers';
 
 interface StoreBaseConfig {
     storefrontTypeId: string;
@@ -47,35 +37,20 @@ export interface DefaultSalesChannelTypes {
 export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
 
     SalesChannelBaseConfig: [
-        async ({ AdminApiContext }, use) => {
-            const requests = {
-                language: getLanguageData('en-GB', AdminApiContext),
-                currencyEUR: getCurrency('EUR', AdminApiContext),
-                invoicePaymentMethodId: getPaymentMethodId(AdminApiContext),
-                defaultShippingMethod: getDefaultShippingMethodId(AdminApiContext),
-                getTaxId: getTaxId(AdminApiContext),
-                deCountryId: getCountryId('de', AdminApiContext),
-                enGBSnippetSetId: getSnippetSetId('en-GB', AdminApiContext),
-                defaultThemeId: getThemeId('Storefront', AdminApiContext),
-            };
-            await Promise.all(Object.values(requests));
-
-            const lang = await requests.language;
-            const currency = await requests.currencyEUR;
-
+        async ({ Country, Currency, Language, PaymentMethod, ShippingMethod, SnippetSet, Tax, Theme }, use) => {
             await use({
-                enGBLocaleId: lang.translationCode.id,
-                enGBLanguageId: lang.id,
+                enGBLocaleId: Language.translationCode.id,
+                enGBLanguageId: Language.id,
                 storefrontTypeId: '8a243080f92e4c719546314b577cf82b',
-                eurCurrencyId: currency.id,
+                eurCurrencyId: Currency.id,
                 defaultCurrencyId: 'b7d2554b0ce847cd82f3ac9bd1c0dfca',
                 defaultLanguageId: '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
-                invoicePaymentMethodId: await requests.invoicePaymentMethodId,
-                defaultShippingMethod: await requests.defaultShippingMethod,
-                taxId: await requests.getTaxId,
-                deCountryId: await requests.deCountryId,
-                enGBSnippetSetId: await requests.enGBSnippetSetId,
-                defaultThemeId: await requests.defaultThemeId,
+                invoicePaymentMethodId: PaymentMethod.id,
+                defaultShippingMethod: ShippingMethod.id,
+                taxId: Tax.id,
+                deCountryId: Country.id,
+                enGBSnippetSetId: SnippetSet.id,
+                defaultThemeId: Theme.id,
                 appUrl: process.env['APP_URL'],
                 adminUrl: process.env['ADMIN_URL'] || `${process.env['APP_URL']}admin/`,
             });

--- a/src/fixtures/ShopwareDataFixtures.ts
+++ b/src/fixtures/ShopwareDataFixtures.ts
@@ -1,0 +1,146 @@
+import { test as base } from '@playwright/test';
+import type { FixtureTypes } from '../types/FixtureTypes';
+import {
+    getCountryId,
+    getCurrency,
+    getLanguageData,
+    getPaymentMethodId,
+    getShippingMethodId,
+    getSnippetSetId,
+    getTaxId,
+    getThemeId,
+} from '../services/ShopwareDataHelpers';
+
+export interface Country {
+    id: string;
+}
+
+export interface Currency {
+    id: string;
+}
+
+export interface Language {
+    id: string;
+    translationCode: { id: string };
+}
+
+export interface PaymentMethod {
+    id: string;
+}
+
+export interface ShippingMethod {
+    id: string;
+}
+
+export interface SnippetSet {
+    id: string;
+}
+
+export interface Tax {
+    id: string;
+}
+
+export interface Theme {
+    id: string;
+}
+
+export interface ShopwareDataFixtureTypes {
+    Country: Country;
+    Currency: Currency;
+    Language: Language;
+    PaymentMethod: PaymentMethod;
+    ShippingMethod: ShippingMethod;
+    SnippetSet: SnippetSet;
+    Tax: Tax;
+    Theme: Theme;
+}
+
+export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
+
+    Country: [
+        async ({ AdminApiContext }, use) => {
+            const countryId = await getCountryId('de', AdminApiContext);
+
+            await use({
+                id: countryId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    Currency: [
+        async ({ AdminApiContext }, use) => {
+            const currency = await getCurrency('EUR', AdminApiContext);
+
+            await use({
+                id: currency.id,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    Language: [
+        async ({ AdminApiContext }, use) => {
+            const language = await getLanguageData('en-GB', AdminApiContext);
+
+            await use(language);
+        },
+        { scope: 'worker' },
+    ],
+
+    PaymentMethod: [
+        async ({ AdminApiContext }, use) => {
+            const paymentMethodId = await getPaymentMethodId(AdminApiContext);
+
+            await use({
+                id: paymentMethodId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    ShippingMethod: [
+        async ({ AdminApiContext }, use) => {
+            const shippingMethodId = await getShippingMethodId('Standard', AdminApiContext);
+
+            await use({
+                id: shippingMethodId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    SnippetSet: [
+        async ({ AdminApiContext }, use) => {
+            const snippedSetId = await getSnippetSetId('en-GB', AdminApiContext);
+
+            await use({
+                id: snippedSetId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    Tax: [
+        async ({ AdminApiContext }, use) => {
+            const taxId = await getTaxId(AdminApiContext);
+
+            await use({
+                id: taxId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+    Theme: [
+        async ({ AdminApiContext }, use) => {
+            const themeId = await getThemeId('Storefront', AdminApiContext);
+
+            await use({
+                id: themeId,
+            });
+        },
+        { scope: 'worker' },
+    ],
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { test as DataFixtures } from './data-fixtures/DataFixtures';
 import { test as ShopAdminTasks } from './tasks/shop-admin-tasks';
 import { test as ShopCustomerTasks } from './tasks/shop-customer-tasks';
 import { test as FeatureService } from './fixtures/Feature';
+import { test as ShopwareDataFixture } from './fixtures/ShopwareDataFixtures';
 
 export * from '@playwright/test';
 export * from './services/ShopwareDataHelpers';
@@ -29,6 +30,7 @@ export type { PageObject } from './types/PageObject';
 export const test = mergeTests(
     HelperFixtures,
     DefaultSalesChannel,
+    ShopwareDataFixture,
     ApiContexts,
     PageContexts,
     Actors,

--- a/src/services/ShopwareDataHelpers.ts
+++ b/src/services/ShopwareDataHelpers.ts
@@ -108,6 +108,8 @@ export const getPaymentMethodId = async (adminApiContext: AdminApiContext, handl
 /**
  * Gives the default shipping method back called Standard
  * @param adminApiContext - An AdminApiContext entity
+ *
+ * @deprecated - Use getShippingMethodId instead
  */
 export const getDefaultShippingMethodId = async (adminApiContext: AdminApiContext): Promise<string> => {
     const resp = await adminApiContext.post('search/shipping-method', {
@@ -117,6 +119,23 @@ export const getDefaultShippingMethodId = async (adminApiContext: AdminApiContex
                 type: 'equals',
                 field: 'name',
                 value: 'Standard',
+            }],
+        },
+    });
+
+    const result = (await resp.json()) as { data: { id: string; active: boolean }[]; total: number };
+
+    return result.data[0].id;
+};
+
+export const getShippingMethodId = async (name: string, adminApiContext: AdminApiContext): Promise<string> => {
+    const resp = await adminApiContext.post('search/shipping-method', {
+        data: {
+            limit: 1,
+            filter: [{
+                type: 'equals',
+                field: 'name',
+                value: name,
             }],
         },
     });

--- a/src/types/FixtureTypes.ts
+++ b/src/types/FixtureTypes.ts
@@ -4,6 +4,7 @@ import { ActorFixtureTypes } from '../fixtures/Actors';
 import { TestDataFixtureTypes } from '../fixtures/TestData';
 import { HelperFixtureTypes } from '../fixtures/HelperFixtures';
 import { DefaultSalesChannelTypes } from '../fixtures/DefaultSalesChannel';
+import { ShopwareDataFixtureTypes } from '../fixtures/ShopwareDataFixtures';
 import { StorefrontPageTypes } from '../page-objects/StorefrontPages';
 import { AdministrationPageTypes } from '../page-objects/AdministrationPages';
 import { DataFixtureTypes } from '../data-fixtures/DataFixtures';
@@ -17,6 +18,7 @@ export interface FixtureTypes extends
     HelperFixtureTypes,
     FeatureFixtureTypes,
     DefaultSalesChannelTypes,
+    ShopwareDataFixtureTypes,
     StorefrontPageTypes,
     AdministrationPageTypes,
     DataFixtureTypes {}


### PR DESCRIPTION
Moving the logic from https://github.com/shopware/acceptance-test-suite/blob/ba108ea999e25e825c46ec308202b247d077c089/src/fixtures/DefaultSalesChannel.ts#L52-L59 to new fixtures within ShopwareDataFixtures for better overwriting of default data.