### PR TITLE
fix: correct headers and data in current request

### DIFF
--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -173,7 +173,14 @@ export class AdminApiContext {
 
         if (response.status() === 401) {
             await this.refreshAccessToken();
-            const updatedOptions = { ...options, headers: { Authorization: `Bearer ${this.options['access_token']}` }};
+            const updatedOptions: RequestOptions<PAYLOAD> = {
+                ...options,
+                data: options?.data ?? undefined,
+                headers: {
+                    ...(options?.headers || {}),
+                    Authorization: `Bearer ${this.options['access_token']}`,
+                },
+            };
             response = await methodMap[method](url, updatedOptions);
         }
 


### PR DESCRIPTION
After token expired, resend request with current data and headers (payload, content type...)