### PR TITLE
ci: use octo-sts for release-please

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/acceptance-test-suite:.*
+claim_pattern:
+  workflow_ref: shopware/acceptance-test-suite/.github/workflows/release.yml@refs/heads/trunk
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: octo-sts/action@v1.0.0
+        id: sts-release
+        with:
+          scope: shopware/acceptance-test-suite
+          identity: release
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
+          token: ${{ steps.sts-release.outputs.token }}
       # The logic below handles the npm publication:
       - uses: actions/checkout@v4
         # these if statements ensure that a publication only occurs when


### PR DESCRIPTION
With the default `GITHUB_TOKEN` the workflows doesn't get triggered on PR creation.