### PR TITLE
fix: Correct select class when create category

### DIFF
--- a/src/page-objects/administration/Categories.ts
+++ b/src/page-objects/administration/Categories.ts
@@ -52,7 +52,7 @@ export class Categories implements PageObject {
 
     this.categoryMenuItemList = page.locator('.sw-context-menu-item');
     this.createCategoryInput = page.getByPlaceholder('Create category').getByRole('textbox');
-    this.confirmCategoryCreationButton = page.locator('.sw-confirm-field').locator('.sw-button--primary');
+    this.confirmCategoryCreationButton = page.locator('.sw-confirm-field').locator('.sw-confirm-field__button--submit');
     this.categoryItems = this.categoryTree.locator('.tree-link');
     this.confirmCategoryCancelButton = page.locator('.sw-confirm-field').locator('.sw-confirm-field__button--cancel');
     this.nameInput = page.getByLabel('Name');


### PR DESCRIPTION
### Description

I unskip this test, but It led to some errors because the button component had changed from `sw-button` to `mt-button`
tests/acceptance/tests/Categories/CreateLinkTypeCategory.spec.ts

![Screenshot 2025-02-20 at 17 27 49](https://github.com/user-attachments/assets/a09ca74b-79b9-40d8-8625-da9e5f9ddf5a)
