### PR TITLE
fix: always check storefront availability after theme assign

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Run Playwright tests against Shopware ${{ matrix.SHOPWARE_VERSION }}
       env:
         APP_URL: http://localhost:${{ matrix.PORT }}
-      run: npx playwright test --repeat-each 1
+      run: npx playwright test --repeat-each 4
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Run Playwright tests against Shopware ${{ matrix.SHOPWARE_VERSION }}
       env:
         APP_URL: http://localhost:${{ matrix.PORT }}
-      run: npx playwright test --repeat-each 4
+      run: npx playwright test --repeat-each 1
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,8 @@ if (process.env['ADMIN_URL']) {
 }
 
 if (!process.env['WEBSERVER_COMMAND']) {
-  if (process.env['WEBSERVER_COMMAND'] === defaultAppUrl) {
-    process.env['WEBSERVER_COMMAND'] = 'docker compose up --pull=always --quiet-pull shopware';
+  if (process.env['APP_URL'] === defaultAppUrl) {
+    process.env['WEBSERVER_COMMAND'] = 'docker compose up --pull=always --quiet-pull';
   } else {
     process.env['WEBSERVER_COMMAND'] = 'sleep 999d';
   }

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -119,11 +119,9 @@ export const test = base.extend<FixtureTypes>({
                 `./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${salesChannel.id}`
             );
 
-            if (isSaasInstance) {
-                while (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
-                    // eslint-disable-next-line playwright/no-wait-for-timeout
-                    await page.waitForTimeout(4000);
-                }
+            while (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
+                // eslint-disable-next-line playwright/no-wait-for-timeout
+                await page.waitForTimeout(4000);
             }
         }
 

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -1,6 +1,7 @@
 import { test as base, expect, Page, BrowserContext } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import { mockApiCalls } from '../services/ApiMocks';
+import { isThemeCompiled } from '../services/ShopInfo';
 
 export interface PageContextTypes {
     AdminPage: Page;

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -1,7 +1,6 @@
 import { test as base, expect, Page, BrowserContext } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import { mockApiCalls } from '../services/ApiMocks';
-import { isSaaSInstance, isThemeCompiled } from '../services/ShopInfo';
 
 export interface PageContextTypes {
     AdminPage: Page;
@@ -109,8 +108,6 @@ export const test = base.extend<FixtureTypes>({
             baseURL: url,
         });
         const page = await context.newPage();
-
-        const isSaasInstance = await isSaaSInstance(AdminApiContext);
 
         if (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
             base.slow();

--- a/src/services/ShopInfo.ts
+++ b/src/services/ShopInfo.ts
@@ -10,7 +10,7 @@ export const isThemeCompiled = async (context: AdminApiContext, storefrontUrl: s
 
     const body = (await response.body()).toString();
 
-    const matches = body.match(/.*"(https:\/\/.*all\.css[^"]*)".*/);
+    const matches = body.match(/.*"(https?:\/\/.*all\.css[^"]*)".*/);
     if (matches && matches?.length > 1) {
         const allCssUrl = matches[1];
 


### PR DESCRIPTION
Due to new async caching/invalidation behavior it's possible that the storefront is not yet fully ready after the theme assignment, even if it's synchronous. So we should always check if the theme is loaded before going forward.