### PR TITLE
fix: adjust the Password input selector

### DIFF
--- a/src/page-objects/administration/FirstRunWizard.ts
+++ b/src/page-objects/administration/FirstRunWizard.ts
@@ -96,7 +96,7 @@ export class FirstRunWizard implements PageObject {
         this.smtpServerHostInput = page.getByLabel('Host');
         this.smtpServerPortInput = page.getByLabel('Port');
         this.smtpServerUsernameInput = page.getByLabel('Username');
-        this.smtpServerPasswordInput = page.getByLabel('Password');
+        this.smtpServerPasswordInput = page.getByLabel('Password', { exact: true });
         this.smtpServerEncryptionInput = page.locator('.sw-single-select__selection-input');
         this.smtpServerSenderAddressInput = page.getByLabel('Sender address');
         this.smtpServerDeliveryAddressInput = page.getByLabel('Delivery address');


### PR DESCRIPTION
Some tests are failing because they find duplicate elements with the select `getByLabel('Password')`.
Adding the option `exact: true` fixes the problem

![image](https://github.com/user-attachments/assets/33dcbf70-fd8f-4c25-918a-bbb6e840801f)
