### PR TITLE
fix: adjust the Password input selector

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -58,7 +58,7 @@ export const test = base.extend<FixtureTypes>({
         await expect(page.url()).toContain('login');
 
         await page.getByLabel(/Username|Email address/).fill(adminUser.username);
-        await page.getByLabel('Password').fill(adminUser.password);
+        await page.getByLabel('Password', { exact: true}).fill(adminUser.password);
 
         const config = await (await AdminApiContext.get('./_info/config')).json() as { bundles: Record<string, { js: string[] | undefined }> };
 


### PR DESCRIPTION
Some tests are failing because they find duplicate elements with the select getByLabel('Password').
Adding the option exact: true fixes the problem

![image](https://github.com/user-attachments/assets/9b57b9a2-1e11-456e-b69b-bea10713bbed)
