### PR TITLE
fix: clear delayed cache after theme assignment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       packages: read
     strategy:
+      fail-fast: false
       matrix:
         include:
           - SHOPWARE_VERSION: ${{ needs.versions.outputs.lts-latest-version }}

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -125,6 +125,7 @@ export const test = base.extend<FixtureTypes>({
 
             if (InstanceMeta.isSaaS) {
                 while (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
+                    await clearDelayedCache(AdminApiContext);
                     // eslint-disable-next-line playwright/no-wait-for-timeout
                     await page.waitForTimeout(4000);
                 }

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -2,7 +2,7 @@ import { test as base, expect, Page, BrowserContext } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import { mockApiCalls } from '../services/ApiMocks';
 import { isThemeCompiled } from '../services/ShopInfo';
-import { clearDelayedCache } from 'src/services/Cache';
+import { clearDelayedCache } from '../services/Cache';
 
 export interface PageContextTypes {
     AdminPage: Page;

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -2,6 +2,7 @@ import { test as base, expect, Page, BrowserContext } from '@playwright/test';
 import type { FixtureTypes } from '../types/FixtureTypes';
 import { mockApiCalls } from '../services/ApiMocks';
 import { isThemeCompiled } from '../services/ShopInfo';
+import { clearDelayedCache } from 'src/services/Cache';
 
 export interface PageContextTypes {
     AdminPage: Page;
@@ -58,7 +59,7 @@ export const test = base.extend<FixtureTypes>({
         await expect(page.url()).toContain('login');
 
         await page.getByLabel(/Username|Email address/).fill(adminUser.username);
-        await page.getByLabel('Password', { exact: true}).fill(adminUser.password);
+        await page.getByLabel('Password', { exact: true }).fill(adminUser.password);
 
         const config = await (await AdminApiContext.get('./_info/config')).json() as { bundles: Record<string, { js: string[] | undefined }> };
 
@@ -92,6 +93,8 @@ export const test = base.extend<FixtureTypes>({
             return res;
         };
 
+        await clearDelayedCache(AdminApiContext);
+
         // Run the test
         await use(page);
 
@@ -102,25 +105,32 @@ export const test = base.extend<FixtureTypes>({
         await AdminApiContext.delete(`user/${uuid}`);
     },
 
-    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext }, use) => {
+    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, InstanceMeta }, use) => {
         const { url, salesChannel } = DefaultSalesChannel;
 
         const context = await browser.newContext({
             baseURL: url,
         });
-        const page = await context.newPage();
 
+        let page;
         if (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
             base.slow();
 
             await AdminApiContext.post(
                 `./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${salesChannel.id}`
             );
+            await clearDelayedCache(AdminApiContext);
 
-            while (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
-                // eslint-disable-next-line playwright/no-wait-for-timeout
-                await page.waitForTimeout(4000);
+            page = await context.newPage();
+
+            if (InstanceMeta.isSaaS) {
+                while (!await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url)) {
+                    // eslint-disable-next-line playwright/no-wait-for-timeout
+                    await page.waitForTimeout(4000);
+                }
             }
+        } else {
+            page = await context.newPage();
         }
 
         await page.goto('./', { waitUntil: 'load' });

--- a/src/services/Cache.ts
+++ b/src/services/Cache.ts
@@ -1,0 +1,6 @@
+import { type AdminApiContext } from './AdminApiContext';
+
+export const clearDelayedCache = async (adminApiContext: AdminApiContext): Promise<void> => {
+    await adminApiContext.delete('./_action/cache-delayed');
+};
+


### PR DESCRIPTION
The `StorefrontPage` is unusable because the theme is unready until the delayed cache is cleared via the scheduled task by accident. 