### PR TITLE
feat(perf): replace goto with document.location for hash urls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,3 +113,9 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test --repeat-each 2
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report-saas
+        path: test-results/
+        retention-days: 1

--- a/src/fixtures/Actors.ts
+++ b/src/fixtures/Actors.ts
@@ -14,8 +14,8 @@ export const test = base.extend<FixtureTypes>({
         await use(shopCustomer);
     },
 
-    ShopAdmin: async ({ AdminPage }, use) => {
-        const shopAdmin = new Actor('Shop administrator', AdminPage);
+    ShopAdmin: async ({ AdminPage, SalesChannelBaseConfig }, use) => {
+        const shopAdmin = new Actor('Shop administrator', AdminPage, SalesChannelBaseConfig.adminUrl);
 
         await use(shopAdmin);
     },

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -98,7 +98,7 @@ export const test = base.extend<FixtureTypes>({
         await expect(page.locator('.sw-skeleton')).toHaveCount(0);
 
         await page.waitForURL((url) => {
-            return url.hash !== 'login';
+            return url.hash !== '#login';
         });
 
         await expect(page.getByText('Administration').first()).toBeVisible();

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -101,7 +101,7 @@ export const test = base.extend<FixtureTypes>({
             return url.hash !== 'login';
         });
 
-        await expect(page.locator('.sw-skeleton')).toHaveCount(0);
+        await expect(page.getByText('Administration')).toBeVisible();
 
         // Run the test
         await use(page);

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -101,7 +101,7 @@ export const test = base.extend<FixtureTypes>({
             return url.hash !== 'login';
         });
 
-        await expect(page.getByText('Administration')).toBeVisible();
+        await expect(page.getByText('Administration').first()).toBeVisible();
 
         // Run the test
         await use(page);

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -95,6 +95,10 @@ export const test = base.extend<FixtureTypes>({
 
         await clearDelayedCache(AdminApiContext);
 
+        await page.waitForURL((url) => {
+            return url.hash !== 'login';
+        });
+
         // Run the test
         await use(page);
 

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -95,9 +95,13 @@ export const test = base.extend<FixtureTypes>({
 
         await clearDelayedCache(AdminApiContext);
 
+        await expect(page.locator('.sw-skeleton')).toHaveCount(0);
+
         await page.waitForURL((url) => {
             return url.hash !== 'login';
         });
+
+        await expect(page.locator('.sw-skeleton')).toHaveCount(0);
 
         // Run the test
         await use(page);

--- a/src/page-objects/administration/CustomerGroupCreate.ts
+++ b/src/page-objects/administration/CustomerGroupCreate.ts
@@ -23,7 +23,7 @@ export class CustomerGroupCreate implements PageObject {
         this.headline = page.getByRole('heading', { name: 'New customer group' });
         this.saveButton = page.getByRole('button', { name: 'Save' });
         this.cancelButton = page.getByRole('button', { name: 'Cancel' });
-        this.cardTitle = page.getByRole('heading', { name: 'Customer group', exact: true });
+        this.cardTitle = page.getByRole('heading', { name: 'Customer group' });
         this.customerGroupNameField = page.locator('#sw-field--customerGroup-name');
         this.customerGroupGrossTaxDisplay = page.locator('#sw-field--castedValue-0');
         this.customerGroupNetTaxDisplay = page.locator('#sw-field--castedValue-1');

--- a/src/page-objects/administration/CustomerGroupCreate.ts
+++ b/src/page-objects/administration/CustomerGroupCreate.ts
@@ -23,7 +23,7 @@ export class CustomerGroupCreate implements PageObject {
         this.headline = page.getByRole('heading', { name: 'New customer group' });
         this.saveButton = page.getByRole('button', { name: 'Save' });
         this.cancelButton = page.getByRole('button', { name: 'Cancel' });
-        this.cardTitle = page.getByRole('heading', { name: 'Customer group' });
+        this.cardTitle = page.getByRole('heading', { name: 'Customer group', exact: true });
         this.customerGroupNameField = page.locator('#sw-field--customerGroup-name');
         this.customerGroupGrossTaxDisplay = page.locator('#sw-field--castedValue-0');
         this.customerGroupNetTaxDisplay = page.locator('#sw-field--castedValue-1');

--- a/src/page-objects/administration/FlowBuilderCreate.ts
+++ b/src/page-objects/administration/FlowBuilderCreate.ts
@@ -5,10 +5,12 @@ export class FlowBuilderCreate implements PageObject {
 
     public readonly saveButton: Locator;
     public readonly header: Locator;
+    public readonly newFlowHeader: Locator;
 
     constructor(public readonly page: Page) {
         this.saveButton = page.locator('.sw-flow-detail__save');
         this.header = page.locator('h2');
+        this.newFlowHeader = page.getByRole('heading', { name: 'New flow' })
     }
 
     url() {

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -5,10 +5,12 @@ import type { Page } from '@playwright/test';
 export class Actor {
     public page: Page;
     public readonly name: string;
+    public baseURL: string | undefined;
 
-    constructor(name: string, page: Page) {
+    constructor(name: string, page: Page, baseURL?: string) {
         this.name = name;
         this.page = page;
+        this.baseURL = baseURL;
     }
 
     expects = expect;
@@ -21,12 +23,16 @@ export class Actor {
     async goesTo(url: string, forceReload = false) {
         const stepTitle = `${this.name} navigates to "${url}"`;
 
+
         await test.step(stepTitle, async () => {
-            if (!forceReload && url.startsWith('#')) {
-                await this.page.evaluate(`document.location = "${url}";`)
-                await this.page.waitForURL((u) => {
-                    return u.hash === url;
-                });
+            if (this.baseURL && !forceReload && url.startsWith('#')) {
+                const baseURLWithoutSlash = this.baseURL.charAt(this.baseURL.length - 1) == '/' ?
+                    this.baseURL.substr(0, this.baseURL.length - 1) : this.baseURL;
+                const fullURL = new URL(url, baseURLWithoutSlash);
+
+                await this.page.evaluate(`document.location = "${url}";`);
+
+                await this.page.waitForURL(`${fullURL.toString()}**`, { timeout: 5000 });
 
                 await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
             } else {

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -23,8 +23,11 @@ export class Actor {
 
         await test.step(stepTitle, async () => {
             if (url.startsWith('#')) {
-                await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
                 await this.page.evaluate(`document.location = "${url}";`)
+                await this.page.waitForURL((url) => {
+                    return url.hash !== 'login';
+                });
+
                 await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
             } else {
                 await this.page.goto(url);

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -24,8 +24,8 @@ export class Actor {
         await test.step(stepTitle, async () => {
             if (!forceReload && url.startsWith('#')) {
                 await this.page.evaluate(`document.location = "${url}";`)
-                await this.page.waitForURL((url) => {
-                    return url.hash !== 'login';
+                await this.page.waitForURL((u) => {
+                    return u.hash === url;
                 });
 
                 await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -18,11 +18,11 @@ export class Actor {
         await test.step(stepTitle, async () => await task());
     }
 
-    async goesTo(url: string) {
+    async goesTo(url: string, forceReload = false) {
         const stepTitle = `${this.name} navigates to "${url}"`;
 
         await test.step(stepTitle, async () => {
-            if (url.startsWith('#')) {
+            if (!forceReload && url.startsWith('#')) {
                 await this.page.evaluate(`document.location = "${url}";`)
                 await this.page.waitForURL((url) => {
                     return url.hash !== 'login';

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-conditional-in-test */
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
@@ -21,18 +22,24 @@ export class Actor {
         const stepTitle = `${this.name} navigates to "${url}"`;
 
         await test.step(stepTitle, async () => {
-            await this.page.goto(url);
+            if (url.startsWith('#')) {
+                await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
+                await this.page.evaluate(`document.location = "${url}";`)
+                await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
+            } else {
+                await this.page.goto(url);
 
-            await this.page.addStyleTag({
-                content: `
-                .sf-toolbar {
-                    width: 0 !important;
-                    height: 0 !important;
-                    display: none !important;
-                    pointer-events: none !important;
-                }
-                `.trim(),
-            });
+                await this.page.addStyleTag({
+                    content: `
+                    .sf-toolbar {
+                        width: 0 !important;
+                        height: 0 !important;
+                        display: none !important;
+                        pointer-events: none !important;
+                    }
+                    `.trim(),
+                });
+            }
         });
     }
 

--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -32,7 +32,7 @@ export class Actor {
 
                 await this.page.evaluate(`document.location = "${url}";`);
 
-                await this.page.waitForURL(`${fullURL.toString()}**`, { timeout: 5000 });
+                await this.page.waitForURL(`${fullURL.toString()}**`, { timeout: 15_000 });
 
                 await expect(this.page.locator('.sw-skeleton')).toHaveCount(0);
             } else {

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -36,6 +36,7 @@ import type {
     ProductCrossSelling,
 } from '../types/ShopwareTypes';
 import { expect } from '@playwright/test';
+import { clearDelayedCache } from './Cache';
 
 export interface SalesChannelRecord {
     salesChannelId: string;
@@ -2521,7 +2522,7 @@ export class TestDataService {
     }
 
     async clearCaches() {
-        await this.AdminApiClient.delete('_action/cache');
+        await clearDelayedCache(this.AdminApiClient);
     }
 
     getBasicCustomFieldSetStruct(overrides: Partial<CustomFieldSet> = {}): Partial<CustomFieldSet> {

--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -16,12 +16,11 @@ test('Administration page objects - General.', async ({
     AdminProductDetail,
 }) => {
     await ShopAdmin.goesTo(AdminCustomerListing.url());
+    await ShopAdmin.expects(AdminCustomerListing.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerListing.addCustomerButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminManufacturerListing.url());
-    await ShopAdmin.expects(AdminManufacturerListing.addManufacturerButton).toBeVisible();
-
     await ShopAdmin.goesTo(AdminManufacturerCreate.url());
+    await ShopAdmin.expects(AdminManufacturerCreate.nameInput).toBeVisible();
     await ShopAdmin.expects(AdminManufacturerCreate.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomerDetail.url(DefaultSalesChannel.customer.id));
@@ -33,16 +32,22 @@ test('Administration page objects - General.', async ({
     await ShopAdmin.expects(AdminCategories.getTreeItemContextButton(category.name)).toBeVisible();
 
     await ShopAdmin.goesTo(AdminLandingPageCreate.url());
+    await ShopAdmin.expects(AdminLandingPageCreate.nameInput).toBeVisible();
     await ShopAdmin.expects(AdminLandingPageCreate.saveLandingPageButton).toBeVisible();
 
     const product = await TestDataService.createBasicProduct();
     const customer = await TestDataService.createCustomer();
     const order = await TestDataService.createOrder([{ product, quantity: 1 }], customer);
     await ShopAdmin.goesTo(AdminOrderDetail.url(order.id));
+    await ShopAdmin.expects(AdminOrderDetail.dataGridContextButton).toBeVisible();
     await ShopAdmin.expects(AdminOrderDetail.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminProductDetail.url(product.id));
     await ShopAdmin.expects(AdminProductDetail.savePhysicalProductButton).toBeVisible();
+    await ShopAdmin.expects(AdminProductDetail.stockInput).toBeVisible();
+
+    await ShopAdmin.goesTo(AdminManufacturerListing.url());
+    await ShopAdmin.expects(AdminManufacturerListing.addManufacturerButton).toBeVisible();
 
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (!InstanceMeta.isSaaS) {

--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -15,7 +15,7 @@ test('Administration page objects - General.', async ({
     AdminOrderDetail,
     AdminProductDetail,
 }) => {
-    await ShopAdmin.goesTo(AdminCustomerListing.url());
+    await ShopAdmin.goesTo(AdminCustomerListing.url(), InstanceMeta.isSaaS);
     await ShopAdmin.expects(AdminCustomerListing.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerListing.addCustomerButton).toBeVisible();
 

--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -15,13 +15,6 @@ test('Administration page objects - General.', async ({
     AdminOrderDetail,
     AdminProductDetail,
 }) => {
-
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (!InstanceMeta.isSaaS) {
-        await ShopAdmin.goesTo(AdminDashboard.url());
-        await ShopAdmin.expects(AdminDashboard.welcomeHeadline).toBeVisible();
-    }
-
     await ShopAdmin.goesTo(AdminCustomerListing.url());
     await ShopAdmin.expects(AdminCustomerListing.addCustomerButton).toBeVisible();
 
@@ -51,4 +44,9 @@ test('Administration page objects - General.', async ({
     await ShopAdmin.goesTo(AdminProductDetail.url(product.id));
     await ShopAdmin.expects(AdminProductDetail.savePhysicalProductButton).toBeVisible();
 
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (!InstanceMeta.isSaaS) {
+        await ShopAdmin.goesTo(AdminDashboard.url());
+        await ShopAdmin.expects(AdminDashboard.welcomeHeadline).toBeVisible();
+    }
 });

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -22,7 +22,7 @@ test('Administration page objects - Settings.', async ({
     await ShopAdmin.expects(AdminCustomerGroupListing.addCustomerGroupButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomerGroupCreate.url());
-    await ShopAdmin.expects(AdminCustomerGroupCreate.cardTitle).toBeVisible();
+    await ShopAdmin.expects(AdminCustomerGroupCreate.customerGroupNameField).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupCreate.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomerGroupDetail.url(DefaultSalesChannel.salesChannel.customerGroupId));

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -17,7 +17,7 @@ test('Administration page objects - Settings.', async ({
     AdminCustomFieldCreate,
     AdminRuleCreate,
 }) => {
-    await ShopAdmin.goesTo(AdminCustomerGroupListing.url());
+    await ShopAdmin.goesTo(AdminCustomerGroupListing.url(), InstanceMeta.isSaaS);
     await ShopAdmin.expects(AdminCustomerGroupListing.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupListing.addCustomerGroupButton).toBeVisible();
 

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -21,7 +21,7 @@ test('Administration page objects - Settings.', async ({
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (!await isSaaSInstance(AdminApiContext)) {
         await ShopAdmin.goesTo(AdminFirstRunWizard.url());
-        await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible();
+        await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible({ timeout: 15_000 });
     }
 
     await ShopAdmin.goesTo(AdminCustomerGroupListing.url());
@@ -49,9 +49,6 @@ test('Administration page objects - Settings.', async ({
     await ShopAdmin.goesTo(AdminCustomFieldCreate.url());
     await ShopAdmin.expects(AdminCustomFieldCreate.saveButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminRuleCreate.url());
-    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
-
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (!InstanceMeta.isSaaS) {
 
@@ -61,4 +58,7 @@ test('Administration page objects - Settings.', async ({
             await ShopAdmin.expects(AdminDataSharing.dataConsentHeadline).toBeVisible();
         }
     }
+
+    await ShopAdmin.goesTo(AdminRuleCreate.url());
+    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
 });

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -29,19 +29,6 @@ test('Administration page objects - Settings.', async ({
     await ShopAdmin.expects(AdminCustomerGroupDetail.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupDetail.saveButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminFlowBuilderCreate.url());
-    await ShopAdmin.expects(AdminFlowBuilderCreate.header).toBeVisible();
-    await ShopAdmin.expects(AdminFlowBuilderCreate.saveButton).toBeVisible();
-
-    await ShopAdmin.goesTo(AdminRuleCreate.url());
-    await ShopAdmin.expects(AdminRuleCreate.nameInput).toBeVisible();
-    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
-
-    const flowId = await getFlowId('Order enters status unconfirmed', AdminApiContext);
-    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
-    await ShopAdmin.expects(AdminFlowBuilderDetail.generalTab).toBeVisible();
-    await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
-
     await ShopAdmin.goesTo(AdminCustomFieldListing.url());
     await ShopAdmin.expects(AdminCustomFieldListing.addNewSetButton).toBeVisible();
 
@@ -65,4 +52,18 @@ test('Administration page objects - Settings.', async ({
         await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
         await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
     }
+
+    const flowId = await getFlowId('Order enters status unconfirmed', AdminApiContext);
+    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
+    await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
+
+    // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload 
+    await ShopAdmin.goesTo(AdminFlowBuilderCreate.url(), true);
+    await ShopAdmin.expects(AdminFlowBuilderCreate.newFlowHeader).toBeVisible();
+    await ShopAdmin.expects(AdminFlowBuilderCreate.saveButton).toBeVisible();
+
+    // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload 
+    await ShopAdmin.goesTo(AdminRuleCreate.url(), true);
+    await ShopAdmin.expects(AdminRuleCreate.nameInput).toBeVisible();
+    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
 });

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -18,28 +18,35 @@ test('Administration page objects - Settings.', async ({
     AdminRuleCreate,
 }) => {
     await ShopAdmin.goesTo(AdminCustomerGroupListing.url());
+    await ShopAdmin.expects(AdminCustomerGroupListing.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupListing.addCustomerGroupButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomerGroupCreate.url());
+    await ShopAdmin.expects(AdminCustomerGroupCreate.cardTitle).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupCreate.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomerGroupDetail.url(DefaultSalesChannel.salesChannel.customerGroupId));
+    await ShopAdmin.expects(AdminCustomerGroupDetail.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupDetail.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminFlowBuilderCreate.url());
+    await ShopAdmin.expects(AdminFlowBuilderCreate.header).toBeVisible();
     await ShopAdmin.expects(AdminFlowBuilderCreate.saveButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
-    await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
+    await ShopAdmin.goesTo(AdminRuleCreate.url());
+    await ShopAdmin.expects(AdminRuleCreate.nameInput).toBeVisible();
+    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
 
     const flowId = await getFlowId('Order enters status unconfirmed', AdminApiContext);
     await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
+    await ShopAdmin.expects(AdminFlowBuilderDetail.generalTab).toBeVisible();
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomFieldListing.url());
     await ShopAdmin.expects(AdminCustomFieldListing.addNewSetButton).toBeVisible();
 
     await ShopAdmin.goesTo(AdminCustomFieldCreate.url());
+    await ShopAdmin.expects(AdminCustomFieldCreate.technicalNameInput).toBeVisible();
     await ShopAdmin.expects(AdminCustomFieldCreate.saveButton).toBeVisible();
 
     // eslint-disable-next-line playwright/no-conditional-in-test
@@ -52,9 +59,10 @@ test('Administration page objects - Settings.', async ({
         }
 
         await ShopAdmin.goesTo(AdminFirstRunWizard.url());
+        await ShopAdmin.expects(AdminFirstRunWizard.welcomeText).toBeVisible();
         await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible({ timeout: 15_000 });
-    }
 
-    await ShopAdmin.goesTo(AdminRuleCreate.url());
-    await ShopAdmin.expects(AdminRuleCreate.saveButton).toBeVisible();
+        await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
+        await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
+    }
 });

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -1,4 +1,4 @@
-import { getFlowId, isSaaSInstance, test } from '../../src';
+import { getFlowId, test } from '../../src';
 
 test('Administration page objects - Settings.', async ({
     InstanceMeta,
@@ -17,13 +17,6 @@ test('Administration page objects - Settings.', async ({
     AdminCustomFieldCreate,
     AdminRuleCreate,
 }) => {
-
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (!await isSaaSInstance(AdminApiContext)) {
-        await ShopAdmin.goesTo(AdminFirstRunWizard.url());
-        await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible({ timeout: 15_000 });
-    }
-
     await ShopAdmin.goesTo(AdminCustomerGroupListing.url());
     await ShopAdmin.expects(AdminCustomerGroupListing.addCustomerGroupButton).toBeVisible();
 
@@ -57,6 +50,9 @@ test('Administration page objects - Settings.', async ({
             await ShopAdmin.goesTo(AdminDataSharing.url());
             await ShopAdmin.expects(AdminDataSharing.dataConsentHeadline).toBeVisible();
         }
+
+        await ShopAdmin.goesTo(AdminFirstRunWizard.url());
+        await ShopAdmin.expects(AdminFirstRunWizard.nextButton).toBeVisible({ timeout: 15_000 });
     }
 
     await ShopAdmin.goesTo(AdminRuleCreate.url());

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -1,4 +1,5 @@
-import {test} from '../../src';
+import { satisfies } from 'compare-versions';
+import { test } from '../../src';
 
 test('Storefront page objects', async ({
     ShopCustomer,
@@ -19,6 +20,7 @@ test('Storefront page objects', async ({
     StorefrontCategory,
     StorefrontSearch,
     TestDataService,
+    InstanceMeta,
 }) => {
 
     const product = await TestDataService.createBasicProduct();
@@ -59,10 +61,13 @@ test('Storefront page objects', async ({
     await ShopCustomer.goesTo(StorefrontAccountProfile.url());
     await ShopCustomer.expects(StorefrontAccountProfile.changeEmailButton).toBeVisible();
 
-    await ShopCustomer.goesTo(StorefrontAccountPayment.url());
-    await ShopCustomer.expects(StorefrontAccountPayment.changeDefaultPaymentButton).toBeVisible();
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (satisfies(InstanceMeta.version, '<=6.7')) {
+        await ShopCustomer.goesTo(StorefrontAccountPayment.url());
+        await ShopCustomer.expects(StorefrontAccountPayment.changeDefaultPaymentButton).toBeVisible();
 
-    await ShopCustomer.goesTo(StorefrontAccountAddresses.url());
-    await ShopCustomer.expects(StorefrontAccountAddresses.addNewAddressButton).toBeVisible();
+        await ShopCustomer.goesTo(StorefrontAccountAddresses.url());
+        await ShopCustomer.expects(StorefrontAccountAddresses.addNewAddressButton).toBeVisible();
+    }
 
 });


### PR DESCRIPTION
The [time to interactive](https://web.dev/articles/tti) of the admin has always been rather slow if nothing is cached and has gotten worse in 6.7 as of now (AFAIK it's still getting optimized). After the first load, it's pretty fast. The problem is that in our tests we use `Page.goto` a lot, but every `.goto` actually forces a full reload of the target page. This makes the tests slower than necessary. An extreme case is the [AdministrationSettings.spec.ts](https://github.com/shopware/acceptance-test-suite/blob/trunk/tests/PageObjects/AdministrationSettings.spec.ts). It takes over 60 seconds to execute even though it just navigates to a bunch of modules.

That's not necessary and is not what is happening for normal clients. We use hash routing in the admin app, which means no request are send to the server by default when the route/hash is changed. To avoid the reloads, I've changed the actor goto method to use the native way to change the url, instead of using the page object. This results in the expected behavior. 

One downside of this method is, that subtle bugs in the admin will cause issues with the navigation. For example, if we try to the change url while the admin is not fully initialized, it will result in an error. I've tried to make it as stable as possible, but we still need to test this with platform and commercial.

**Before:**
![image](https://github.com/user-attachments/assets/aef48afd-bfca-4085-8c01-439cdf53dec0)
[trace.zip](https://github.com/user-attachments/files/19091560/trace.zip)

**After:**
![image](https://github.com/user-attachments/assets/1bff8835-85d6-401e-825f-92cce1ffdde2)

[trace.zip](https://github.com/user-attachments/files/19091519/trace.zip)

**Diff:**
- 58s -> 29.5s (50% reduction)
- 8552 requests ->2652 requests (70% reduction)

I've tried this locally on platform and it reduced the runtime of admin related tests by ~25%.
