### PR TITLE
fix: customer bulk edit tags

### DIFF
--- a/src/page-objects/administration/CustomerBulkEdit.ts
+++ b/src/page-objects/administration/CustomerBulkEdit.ts
@@ -53,7 +53,7 @@ export class CustomerBulkEdit implements PageObject{
     const changeTag = page.locator('.sw-bulk-edit-change-field-tags');
     this.changeTagsCheckbox = changeTag.getByRole('checkbox', { name: 'Change: Tags' });
     this.changeTypeSelect = changeTag.locator('.sw-bulk-edit-change-type__selection');
-    this.enterTagsSelect = changeTag.locator('.sw-entity-multi-select');
+    this.enterTagsSelect = changeTag.locator('.sw-entity-multi-select input');
 
     //Custom fields
     const customFields = page.locator('.sw-bulk-edit__custom-fields');


### PR DESCRIPTION
The bulk edit task currently clicks at the tag multi select every time a tag should be selected. As the close icon is exactly in the middle of the multi select, the first selected tag is deselected again.

![image](https://github.com/user-attachments/assets/27dbe70c-cea2-49d1-905c-8d26d5c4cc8b)
