### PR TITLE
feat: extend ats with keyboard first support and custom a11y assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [11.16.0](https://github.com/shopware/acceptance-test-suite/compare/v11.15.4...v11.16.0) (2025-06-26)
+
+
+### Features
+
+* new locators for product detail page and a new task ([#405](https://github.com/shopware/acceptance-test-suite/issues/405)) ([3b5fdef](https://github.com/shopware/acceptance-test-suite/commit/3b5fdefe8c01fad80de96eca1ae5504eee0e1b4d))
+
 ## [11.15.4](https://github.com/shopware/acceptance-test-suite/compare/v11.15.3...v11.15.4) (2025-06-04)
 
 

--- a/README.md
+++ b/README.md
@@ -808,6 +808,10 @@ You can create a new TypeScript class that **extends** the base `TestDataService
 import { TestDataService } from '@shopware-ag/acceptance-test-suite';
 
 export class CustomTestDataService extends TestDataService {
+
+    constructor(AdminApiContext, DefaultSalesChannel) {
+        super(...);
+    }
     
     async createCustomCustomerGroup(data: Partial<CustomerGroup>) {
         const response = await this.adminApi.post('customer-group?_response=true', {
@@ -832,14 +836,16 @@ Example from `AcceptanceTest.ts`:
 
 ```typescript
 import { test as base } from '@shopware-ag/acceptance-test-suite';
-import type { FixtureTypes } from '@shopware-ag/acceptance-test-suite';
-import { CustomTestDataService } from './CustomTestData';
+import type { FixtureTypes } from './BaseTestFile';
+import { CustomTestDataService } from './CustomTestDataService';
 
-export * from '@shopware-ag/acceptance-test-suite';
+export interface CustomTestDataServiceType {
+    TestDataService: CustomTestDataService;
+}
 
-export const test = base.extend<FixtureTypes & CustomTestDataService>({
+export const test = base.extend<FixtureTypes & CustomTestDataServiceType>({
     TestDataService: async ({ AdminApiContext, DefaultSalesChannel }, use) => {
-        const service = new CustomTestDataService(AdminApiContext, DefaultSalesChannel);
+        const service = new CustomTestDataService(AdminApiContext, DefaultSalesChannel.salesChannel);
         await use(service);
         await service.cleanUp();
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "11.15.4",
+  "version": "11.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shopware-ag/acceptance-test-suite",
-      "version": "11.15.4",
+      "version": "11.16.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "11.15.4",
+  "version": "11.16.0",
   "description": "Shopware Acceptance Test Suite",
   "author": "shopware AG",
   "license": "MIT",

--- a/src/fixtures/TestData.ts
+++ b/src/fixtures/TestData.ts
@@ -2,6 +2,9 @@ import { test as base } from '@playwright/test';
 import { TestDataService } from '../services/TestDataService';
 import type { FixtureTypes } from '../types/FixtureTypes';
 
+const ATS_SKIP_CLEANUP: boolean = ['1', 'true'].includes(process.env['ATS_SKIP_CLEANUP'] || '');
+const ATS_EXEC_CLEANUP = !ATS_SKIP_CLEANUP;
+
 export interface TestDataFixtureTypes {
     TestDataService: TestDataService;
 }
@@ -21,6 +24,8 @@ export const test = base.extend<FixtureTypes>({
 
         await use(DataService);
 
-        await DataService.cleanUp();
+        if (ATS_EXEC_CLEANUP) {
+            await DataService.cleanUp();
+        }
     },
 });

--- a/src/page-objects/administration/ProductDetail.ts
+++ b/src/page-objects/administration/ProductDetail.ts
@@ -53,6 +53,11 @@ export class ProductDetail implements PageObject {
      */
     public readonly variantsTabLink: Locator;
     public readonly specificationsTabLink: Locator;
+    public readonly advancedPricingTabLink: Locator;
+    public readonly layoutTabLink: Locator;
+    public readonly crossSellingTabLink: Locator;
+    public readonly SEOTabLink: Locator;
+    public readonly reviewsTabLink: Locator;
 
     /**
      * Variants Generation
@@ -88,6 +93,15 @@ export class ProductDetail implements PageObject {
         this.saveButtonCheckMark = page.locator('.icon--regular-checkmark-xs');
         this.saveButtonLoadingSpinner = page.locator('sw-loader');
 
+        // Tabs
+        this.specificationsTabLink = page.getByRole('tab', { name: 'Specifications' });
+        this.advancedPricingTabLink = page.getByRole('tab', { name: 'Advanced pricing' });
+        this.variantsTabLink = page.getByRole('tab', { name: 'Variants' });
+        this.layoutTabLink = page.getByRole('tab', { name: 'Layout' });
+        this.crossSellingTabLink = page.getByRole('tab', { name: 'Cross Selling' });
+        this.SEOTabLink = page.getByRole('tab', { name: 'SEO' })
+        this.reviewsTabLink = page.getByRole('tab', { name: 'Reviews' });
+
         // General Info
         this.manufacturerDropdownText = page.locator('.sw-select-product__select_manufacturer');
 
@@ -115,8 +129,6 @@ export class ProductDetail implements PageObject {
         this.coverImage = page.locator('.sw-product-media-form__cover-image');
         this.productImage = page.locator('.sw-media-preview-v2__item');
 
-        this.variantsTabLink = page.getByRole('tab', { name: 'Variants' });
-
         this.generateVariantsButton = page.getByRole('button', { name: 'Generate variants' });
         this.variantsModal = page.getByRole('dialog', { name: 'Generate variants' });
         this.variantsModalHeadline = this.variantsModal.getByRole('heading', { name: 'Generate variants' });
@@ -134,7 +146,6 @@ export class ProductDetail implements PageObject {
         this.propertyOptionSizeMedium = this.propertyOptionGrid.getByRole('row', { name: 'Medium' }).getByRole('checkbox');
         this.propertyOptionSizeLarge = this.propertyOptionGrid.getByRole('row', { name: 'Large' }).getByRole('checkbox');
 
-        this.specificationsTabLink = page.getByRole('tab', { name: 'Specifications' });
         if (satisfies(instanceMeta.version, '<6.7')) {
             this.customFieldCard = page.locator('.sw-card').getByText('Custom fields');
         } else {

--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -27,6 +27,33 @@ export class ProductDetail implements PageObject {
     public readonly productDetailConfiguratorGroupTitle: Locator;
     public readonly productDetailConfiguratorOptionInputs: Locator;
 
+    public readonly productName: Locator;
+
+    //Reviews Tab
+    public readonly reviewsTab: Locator;
+    public readonly reviewTeaserButton: Locator;
+    public readonly reviewTeaserText: Locator;
+    public readonly reviewListingItems: Locator;
+    public readonly reviewEmptyListingText: Locator;
+    public readonly reviewLoginForm: Locator;
+    public readonly forgottenPasswordLink: Locator;
+    public readonly reviewForm: Locator;
+    public readonly reviewRatingPoints: Locator;
+    public readonly reviewRatingText: Locator;
+    public readonly reviewSubmitMessage: Locator;
+    public readonly reviewCounter: Locator;
+    public readonly reviewItemRatingPoints: Locator;
+    public readonly reviewItemTitle: Locator;
+    public readonly reviewReviewTextInput: Locator;
+    public readonly reviewItemContent: Locator;
+    public readonly reviewLoginButton: Locator;
+    public readonly reviewEmailInput: Locator;
+    public readonly reviewPasswordInput: Locator;
+    public readonly reviewTitleInput: Locator;
+    public readonly reviewSubmitButton: Locator;
+    public readonly productReviewsLink: Locator;
+    public readonly productReviewRating: Locator;
+
     constructor(public readonly page: Page) {
 
         this.addToCartButton = page.getByRole('button', { name: 'Add to shopping cart' });
@@ -51,6 +78,45 @@ export class ProductDetail implements PageObject {
         this.productDetailConfigurator = page.locator('.product-detail-configurator');
         this.productDetailConfiguratorGroupTitle = page.locator('.product-detail-configurator-group-title');
         this.productDetailConfiguratorOptionInputs = page.locator('.product-detail-configurator-option-input');
+
+        this.productName = page.locator('.product-detail-name');
+
+        this.productReviewRating = page.locator('.product-detail-reviews .product-review-rating');
+        this.productReviewsLink = page.locator('.product-detail-reviews .product-detail-reviews-link');
+        this.reviewsTab = this.page.getByRole('tab', { name: 'Reviews' });
+        this.reviewTeaserButton = this.page.locator('.product-detail-review-teaser-btn');
+        this.reviewTeaserText = this.page.locator('.product-detail-review-teaser .h4');
+        this.reviewListingItems = this.page.locator('.product-detail-review-item');
+        this.reviewEmptyListingText = this.page.getByText('No reviews found. Share your insights with others.');
+        this.reviewLoginForm = this.page.locator('.product-detail-review-login');
+        this.forgottenPasswordLink = this.page.getByRole('link', { name: 'I have forgotten my password.' });
+        this.reviewLoginButton = this.page.getByRole('button', { name: 'Log in' });
+        this.reviewEmailInput = this.page.getByLabel('Your email address');
+        this.reviewPasswordInput = this.page.getByLabel('Your password');
+        this.reviewForm = this.page.locator('.product-detail-review-form');
+        this.reviewTitleInput = this.page.getByLabel('Title');
+        this.reviewReviewTextInput = this.page.getByLabel('Your review');
+        this.reviewSubmitButton = this.page.locator('.btn-review-submit');
+        this.reviewRatingPoints = this.page.locator('.product-detail-review-form-star');
+        this.reviewRatingText = this.page.locator('.product-detail-review-form-rating-text');
+        this.reviewCounter = this.page.locator('.product-detail-review-counter');
+        this.reviewItemRatingPoints = this.page.locator('.product-detail-review-item-points .point-full');
+        this.reviewItemTitle = this.page.locator('.product-detail-review-item-title');
+        this.reviewItemContent = this.page.locator('.product-detail-review-item-content');
+        this.reviewSubmitMessage = this.page.getByText('Thank you for submitting your review. We will examine the review and eventually unlock it, please be patient.');
+    }
+
+    async getReviewFilterRowOptionsByName(filterOptionName: string) {
+        const rowLocators = this.page.locator('.product-detail-review-filter').filter({ hasText: filterOptionName });
+        const reviewFilterOptionCheckbox = rowLocators.getByLabel(filterOptionName);
+        const reviewFilterOptionText = rowLocators.locator('.custom-control-label');
+        const reviewFilterOptionPercentage = rowLocators.locator('.product-detail-review-share');
+
+        return {
+            reviewFilterOptionCheckbox: reviewFilterOptionCheckbox,
+            reviewFilterOptionText: reviewFilterOptionText,
+            reviewFilterOptionPercentage: reviewFilterOptionPercentage,
+        }
     }
 
     url(productData: Product) {

--- a/src/tasks/shop-admin-tasks.ts
+++ b/src/tasks/shop-admin-tasks.ts
@@ -6,6 +6,7 @@ import { CreateLinkTypeCategory } from './shop-admin/Category/CreateLinkTypeCate
 import { BulkEditProducts } from './shop-admin/Product/BulkEditProducts';
 import { BulkEditCustomers } from './shop-admin/Customers/BulkEditCustomers';
 import { AssignEntitiesToRule } from './shop-admin/Rule/AssignEntitiesToRule';
+import { LoginViaReviewsTab } from './shop-customer/Account/LoginViaReviewsTab';
 
 export const test = mergeTests(
     SaveProduct,
@@ -14,4 +15,5 @@ export const test = mergeTests(
     BulkEditProducts,
     BulkEditCustomers,
     AssignEntitiesToRule,
+    LoginViaReviewsTab,
 );

--- a/src/tasks/shop-customer/Account/LoginViaReviewsTab.ts
+++ b/src/tasks/shop-customer/Account/LoginViaReviewsTab.ts
@@ -1,0 +1,27 @@
+import { test as base } from '@playwright/test';
+import type { Task } from '../../../types/Task';
+import type { FixtureTypes} from '../../../types/FixtureTypes';
+import type { Customer, Product } from '../../../types/ShopwareTypes';
+
+export const LoginViaReviewsTab = base.extend<{ LoginViaReviewsTab: Task }, FixtureTypes>({
+    LoginViaReviewsTab: async ({ ShopCustomer, DefaultSalesChannel, StorefrontProductDetail }, use) => {
+        const task = (product: Product, customCustomer?: Customer) => {
+            return async function LoginViaReviewsTab() {
+
+                const customer = customCustomer ? customCustomer : DefaultSalesChannel.customer;
+
+                await ShopCustomer.goesTo(StorefrontProductDetail.url(product));
+                await StorefrontProductDetail.reviewsTab.click();
+                await StorefrontProductDetail.reviewTeaserButton.click();
+
+                await StorefrontProductDetail.reviewEmailInput.fill(customer.email);
+                await StorefrontProductDetail.reviewPasswordInput.fill(customer.password);
+                await StorefrontProductDetail.reviewLoginButton.click();
+
+                await ShopCustomer.expects(StorefrontProductDetail.productName).toHaveText(product.name);
+            }
+        };
+
+        await use(task);
+    },
+});


### PR DESCRIPTION
This is a proof of concept to extend the ATS to include additional support for accessibility

- Adapt the RegisteredUserBuysProduct.spec.ts to only navigate and interact with the storefront using a keyboard (does not need to include the storefront skip links)
- Adapt the RegisteredUserBuysProduct.spec.ts to only navigate and interact with the storefront using a keyboard and include tabbing between elements
- Create a custom assertion to check for visible focus indicators in the ATS
- Adapt the RegisteredUserBuysProduct.spec.ts to only navigate and interact with the storefront using a keyboard, including the https://github.com/shopware/shopware/issues/10891, and bundled with a collection of assertions to cover missing [actionability checks](https://playwright.dev/docs/actionability#introduction)