### PR TITLE
feat: add HideElementsForScreenshot helper

### DIFF
--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -5,6 +5,7 @@ import type { FixtureTypes } from '../types/FixtureTypes';
 import { getCurrency, getLanguageData } from '../services/ShopwareDataHelpers';
 import { AdminApiContext } from '../services/AdminApiContext';
 import { satisfies } from 'compare-versions';
+import type { Page } from '@playwright/test';
 
 type FeaturesType = Record<string, boolean>;
 
@@ -16,6 +17,7 @@ export interface HelperFixtureTypes {
         isSaaS: boolean,
         features: FeaturesType,
     },
+    HideElementsForScreenshot: (page: Page, selectors: string[]) => Promise<void>
 }
 
 export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
@@ -85,4 +87,21 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
         },
         { scope: 'worker' },
     ],
+
+    HideElementsForScreenshot: [
+        async ({ }, use) => {
+        const fn = async (page: Page, selectors: string[]) => {
+            if (!selectors.length) return;
+
+            const css = selectors
+            .map(selector => `${selector} { display: none !important; }`)
+            .join('\n');
+
+            await page.addStyleTag({ content: css });
+        };
+
+        await use(fn);
+        },
+        { scope: 'worker' },
+  ],
 });

--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -5,7 +5,6 @@ import type { FixtureTypes } from '../types/FixtureTypes';
 import { getCurrency, getLanguageData } from '../services/ShopwareDataHelpers';
 import { AdminApiContext } from '../services/AdminApiContext';
 import { satisfies } from 'compare-versions';
-import type { Page } from '@playwright/test';
 
 type FeaturesType = Record<string, boolean>;
 
@@ -17,7 +16,8 @@ export interface HelperFixtureTypes {
         isSaaS: boolean,
         features: FeaturesType,
     },
-    HideElementsForScreenshot: (page: Page, selectors: string[]) => Promise<void>
+    HideAdminElementsForScreenshot: (selectors: string[]) => Promise<void>,
+    HideStorefrontElementsForScreenshot: (selectors: string[]) => Promise<void>,
 }
 
 export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
@@ -88,20 +88,39 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
         { scope: 'worker' },
     ],
 
-    HideElementsForScreenshot: [
-        async ({ }, use) => {
-        const fn = async (page: Page, selectors: string[]) => {
-            if (!selectors.length) return;
+    HideAdminElementsForScreenshot: [
+        async ({ AdminPage }, use) => {
 
-            const css = selectors
-            .map(selector => `${selector} { display: none !important; }`)
-            .join('\n');
+            const fn = async (selectors: string[]) => {
+                if (!selectors.length) return;
 
-            await page.addStyleTag({ content: css });
-        };
+                const css = selectors
+                    .map(selector => `${selector} { display: none !important; }`)
+                    .join('\n');
 
-        await use(fn);
+                await AdminPage.addStyleTag({ content: css });
+            };
+
+            await use(fn);
         },
         { scope: 'worker' },
-  ],
+    ],
+    
+    HideStorefrontElementsForScreenshot: [
+        async ({ StorefrontPage }, use) => {
+
+            const fn = async (selectors: string[]) => {
+                if (!selectors.length) return;
+
+                const css = selectors
+                    .map(selector => `${selector} { display: none !important; }`)
+                    .join('\n');
+
+                await StorefrontPage.addStyleTag({ content: css });
+            };
+
+            await use(fn);
+        },
+        { scope: 'worker' },
+    ],
 });

--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -5,6 +5,7 @@ import type { FixtureTypes } from '../types/FixtureTypes';
 import { getCurrency, getLanguageData } from '../services/ShopwareDataHelpers';
 import { AdminApiContext } from '../services/AdminApiContext';
 import { satisfies } from 'compare-versions';
+import type { Page } from '@playwright/test';
 
 type FeaturesType = Record<string, boolean>;
 
@@ -16,8 +17,7 @@ export interface HelperFixtureTypes {
         isSaaS: boolean,
         features: FeaturesType,
     },
-    HideAdminElementsForScreenshot: (selectors: string[]) => Promise<void>,
-    HideStorefrontElementsForScreenshot: (selectors: string[]) => Promise<void>,
+    HideElementsForScreenshot: (page: Page, selectors: string[]) => Promise<void>
 }
 
 export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
@@ -88,35 +88,16 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
         { scope: 'worker' },
     ],
 
-    HideAdminElementsForScreenshot: [
-        async ({ AdminPage }, use) => {
-
-            const fn = async (selectors: string[]) => {
+    HideElementsForScreenshot: [
+        async ({ }, use) => {
+            const fn = async (page: Page, selectors: string[]) => {
                 if (!selectors.length) return;
 
                 const css = selectors
-                    .map(selector => `${selector} { display: none !important; }`)
-                    .join('\n');
+                .map(selector => `${selector} { display: none !important; }`)
+                .join('\n');
 
-                await AdminPage.addStyleTag({ content: css });
-            };
-
-            await use(fn);
-        },
-        { scope: 'worker' },
-    ],
-    
-    HideStorefrontElementsForScreenshot: [
-        async ({ StorefrontPage }, use) => {
-
-            const fn = async (selectors: string[]) => {
-                if (!selectors.length) return;
-
-                const css = selectors
-                    .map(selector => `${selector} { display: none !important; }`)
-                    .join('\n');
-
-                await StorefrontPage.addStyleTag({ content: css });
+                await page.addStyleTag({ content: css });
             };
 
             await use(fn);


### PR DESCRIPTION
This PR introduces a small refactoring to improve the readability and maintainability of our visual tests.

Extracted the inline addStyleTag call used for hiding dynamic or irrelevant UI elements into a reusable helper method: hideElementsForScreenshot.

The helper accepts a page instance and an array of selectors to hide using display: none !important.

This makes it easier for others—especially those less familiar with CSS—to understand what the code does without having to parse raw CSS.

Also improves consistency across test files by avoiding repetition.

Thanks @vanpham-sw  for the suggestion — wrapping this into a method definitely improves clarity 🙌


SEE COMMENT: https://github.com/shopware/shopware/pull/9771/files#r2168684991