### PR TITLE
fix: change version condition to only expect the text-editor in 6.8

### DIFF
--- a/src/page-objects/administration/CustomerGroupCreate.ts
+++ b/src/page-objects/administration/CustomerGroupCreate.ts
@@ -32,9 +32,13 @@ export class CustomerGroupCreate implements PageObject {
 
         if (satisfies(instanceMeta.version, '<6.8')) {
             this.signupFormIntroduction = page.locator('.sw-text-editor__content-editor');
-            this.signupFormSeoDescription = page.locator('#sw-field--customerGroup-registrationSeoMetaDescription');
         } else {
             this.signupFormIntroduction = page.locator('.mt-text-editor__content-editor');
+        }
+
+        if (satisfies(instanceMeta.version, '<6.7')) {
+            this.signupFormSeoDescription = page.locator('#sw-field--customerGroup-registrationSeoMetaDescription');
+        } else {
             this.signupFormSeoDescription = page.getByRole('textbox', { name: 'SEO meta description' });
         }
 


### PR DESCRIPTION
The `instanceMeta.version` check in the customer group page object also included a normal text field. This should still remain the `<mt-text-field>` in current 6.7.

Split up the conditions:
- text field: 
   - 6.7: `mt-text-field`
   - before 6.7: `sw-field`

- text editor: 
    - 6.8: `mt-text-editor`
    - before 6.8: `sw-text-editor`