### PR TITLE
fix: disable services locator tests in SaaS

### DIFF
--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '../../src';
 import { satisfies } from 'compare-versions';
+import { expect } from '@playwright/test';
 
 
 test('Administration page objects - General.', async ({
@@ -70,15 +71,29 @@ test('Administration page objects - General.', async ({
     await ShopAdmin.expects(AdminDashboard.adminMenuLogoutButton).toBeVisible();
 
     // eslint-disable-next-line playwright/no-conditional-in-test
-    if (satisfies(InstanceMeta.version, '>=6.7.1')) {
+    if (satisfies(InstanceMeta.version, '>=6.7.1') && !InstanceMeta.isSaaS) {
         await ShopAdmin.goesTo(AdminShopwareServices.url());
         await ShopAdmin.expects(AdminShopwareServices.header).toBeVisible();
-        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible();
+        try {
+            await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible()
+        } catch (e) {
+            await AdminShopwareServices.activateServicesButton.click();
+        }
+
         await AdminShopwareServices.deactivateServicesButton.click();
         await ShopAdmin.expects(AdminShopwareServices.deactivateServicesModal).toBeVisible();
         await ShopAdmin.expects(AdminShopwareServices.deactivateServicesConfirmButton).toBeVisible();
+        const disableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/disable`);
         await AdminShopwareServices.deactivateServicesConfirmButton.click();
-        await ShopAdmin.expects(AdminShopwareServices.activateServicesButton).toBeVisible();
+        const disableResponse = await disableResponsePromise;
+        expect(disableResponse.ok()).toBeTruthy();
+        // enable the services again for further tests
+        await ShopAdmin.expects(AdminShopwareServices.activateServicesButton).toBeVisible({ timeout: 15000 });
+        const enableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/enable`);
         await AdminShopwareServices.activateServicesButton.click();
+        const enableResponse = await enableResponsePromise;
+        expect(enableResponse.ok()).toBeTruthy();
+        await AdminShopwareServices.page.reload();
+        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible({ timeout: 15000 });
     }
 });

--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -54,7 +54,7 @@ test('Administration page objects - General.', async ({
     await ShopAdmin.goesTo(AdminManufacturerListing.url());
     await ShopAdmin.expects(AdminManufacturerListing.addManufacturerButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminDashboard.url());
+    await ShopAdmin.goesTo(AdminDashboard.url(), InstanceMeta.isSaaS);
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (!InstanceMeta.isSaaS) {
         await ShopAdmin.expects(AdminDashboard.welcomeHeadline).toBeVisible();

--- a/tests/PageObjects/AdministrationGeneral.spec.ts
+++ b/tests/PageObjects/AdministrationGeneral.spec.ts
@@ -1,7 +1,4 @@
 import { test } from '../../src';
-import { satisfies } from 'compare-versions';
-import { expect } from '@playwright/test';
-
 
 test('Administration page objects - General.', async ({
     InstanceMeta,
@@ -17,7 +14,6 @@ test('Administration page objects - General.', async ({
     TestDataService,
     AdminOrderDetail,
     AdminProductDetail,
-    AdminShopwareServices,
 }) => {
     await ShopAdmin.goesTo(AdminCustomerListing.url(), InstanceMeta.isSaaS);
     await ShopAdmin.expects(AdminCustomerListing.headline).toBeVisible();
@@ -54,46 +50,14 @@ test('Administration page objects - General.', async ({
     await ShopAdmin.goesTo(AdminManufacturerListing.url());
     await ShopAdmin.expects(AdminManufacturerListing.addManufacturerButton).toBeVisible();
 
-    await ShopAdmin.goesTo(AdminDashboard.url(), InstanceMeta.isSaaS);
+    await ShopAdmin.goesTo(AdminDashboard.url());
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (!InstanceMeta.isSaaS) {
         await ShopAdmin.expects(AdminDashboard.welcomeHeadline).toBeVisible();
     }
 
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (satisfies(InstanceMeta.version, '>=6.7.1')) {
-        await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toBeVisible();
-        await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toContainText('Introducing Shopware Services');
-        await ShopAdmin.expects(AdminDashboard.shopwareServicesExploreNowButton).toBeVisible();
-    }
     await ShopAdmin.expects(AdminDashboard.adminMenuUserActions).toBeVisible();
     await AdminDashboard.adminMenuUserActions.click();
     await ShopAdmin.expects(AdminDashboard.adminMenuLogoutButton).toBeVisible();
 
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (satisfies(InstanceMeta.version, '>=6.7.1') && !InstanceMeta.isSaaS) {
-        await ShopAdmin.goesTo(AdminShopwareServices.url());
-        await ShopAdmin.expects(AdminShopwareServices.header).toBeVisible();
-        try {
-            await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible()
-        } catch (e) {
-            await AdminShopwareServices.activateServicesButton.click();
-        }
-
-        await AdminShopwareServices.deactivateServicesButton.click();
-        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesModal).toBeVisible();
-        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesConfirmButton).toBeVisible();
-        const disableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/disable`);
-        await AdminShopwareServices.deactivateServicesConfirmButton.click();
-        const disableResponse = await disableResponsePromise;
-        expect(disableResponse.ok()).toBeTruthy();
-        // enable the services again for further tests
-        await ShopAdmin.expects(AdminShopwareServices.activateServicesButton).toBeVisible({ timeout: 15000 });
-        const enableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/enable`);
-        await AdminShopwareServices.activateServicesButton.click();
-        const enableResponse = await enableResponsePromise;
-        expect(enableResponse.ok()).toBeTruthy();
-        await AdminShopwareServices.page.reload();
-        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible({ timeout: 15000 });
-    }
 });

--- a/tests/ShopwareServices.spec.ts
+++ b/tests/ShopwareServices.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../src';
+import { satisfies } from 'compare-versions';
+
+test('Shopware Services', async ({
+    InstanceMeta,
+    ShopAdmin,
+    AdminDashboard,
+    AdminShopwareServices,
+}) => {
+
+// eslint-disable-next-line playwright/no-conditional-in-test
+    if (satisfies(InstanceMeta.version, '>=6.7.1') && !InstanceMeta.isSaaS) {
+        await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toBeVisible();
+        await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toContainText('Introducing Shopware Services');
+        await ShopAdmin.expects(AdminDashboard.shopwareServicesExploreNowButton).toBeVisible();
+
+        await ShopAdmin.goesTo(AdminShopwareServices.url());
+        await ShopAdmin.expects(AdminShopwareServices.header).toBeVisible();
+        try {
+            await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible()
+        } catch (e) {
+            await AdminShopwareServices.activateServicesButton.click();
+        }
+
+        await AdminShopwareServices.deactivateServicesButton.click();
+        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesModal).toBeVisible();
+        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesConfirmButton).toBeVisible();
+        const disableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/disable`);
+        await AdminShopwareServices.deactivateServicesConfirmButton.click();
+        const disableResponse = await disableResponsePromise;
+        expect(disableResponse.ok()).toBeTruthy();
+        // enable the services again for further tests
+        await ShopAdmin.expects(AdminShopwareServices.activateServicesButton).toBeVisible({ timeout: 15000 });
+        const enableResponsePromise = AdminShopwareServices.page.waitForResponse(`${ process.env['APP_URL'] }api/services/enable`);
+        await AdminShopwareServices.activateServicesButton.click();
+        const enableResponse = await enableResponsePromise;
+        expect(enableResponse.ok()).toBeTruthy();
+        await AdminShopwareServices.page.reload();
+        await ShopAdmin.expects(AdminShopwareServices.deactivateServicesButton).toBeVisible({ timeout: 15000 });
+    }
+});


### PR DESCRIPTION
- Disable services locator tests in SaaS because of possible race condition (one cloud instance for all tests) -> services are changing the whole instance behaviour, it is risky if that test fails during the execution