### PR TITLE
fix: generate random 3 digit id for isoCode

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -2011,11 +2011,29 @@ export class TestDataService {
     getCurrencyStruct(overrides: Partial<Currency> = {}, roundingDecimals: number): Partial<Currency> {
         const { uuid: currencyUuid, id: currencyId } = this.IdProvider.getIdPair();
 
+        // Generate a random 3-character alphanumeric string
+        const randomId: string = (() => {
+            const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+            const digits = '0123456789';
+            const allChars = letters + digits;
+
+            const result = Array.from({ length: 3 }, () =>
+                allChars.charAt(Math.floor(Math.random() * allChars.length)),
+            );
+
+            if (!result.some(char => digits.includes(char))) {
+                const randomIndex = Math.floor(Math.random() * result.length);
+                result[randomIndex] = digits.charAt(Math.floor(Math.random() * digits.length));
+            }
+
+            return result.join('');
+        })();
+
         const basicCurrency = {
             id: currencyUuid,
             name: 'Currency-' + currencyId,
             shortName: 'CUR' + currencyId,
-            isoCode: '' + currencyId.substring(0, 3),
+            isoCode: randomId,
             symbol: 'C$',
             factor: 2.4,
             itemRounding: {


### PR DESCRIPTION
Actual: 
isoCode is not always unique, because sometimes the deletion of currency fails.

```
errors": [
    {
      "code": "1062",
      "status": "500",
      "title": "Internal Server Error",
      "detail": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '202' for key 'currency.uniq.currency.iso_code'"
    }
```

Solution:
Add some more randomness to the 3 digits, including numbers and chars.