### PR TITLE
feat: task check visibility of products

### DIFF
--- a/src/tasks/shop-customer-tasks.ts
+++ b/src/tasks/shop-customer-tasks.ts
@@ -27,6 +27,7 @@ import { SearchForTerm } from './shop-customer/Search/SearchForTerm';
 import { ValidateAccessibility } from './shop-customer/Accessibility/ValidateAccessibility';
 import { AddProductToCartFromWishlist, AddProductToWishlist, RemoveProductFromWishlist } from './shop-customer/Wishlist/WishlistActions';
 import { SelectProductFilterOption } from './shop-customer/Product/SelectProductFilterOption';
+import { CheckVisibilityInHome } from './shop-customer/Listing/CheckVisibilityInHome';
 
 export const test = mergeTests(
     Login,
@@ -54,4 +55,5 @@ export const test = mergeTests(
     AddProductToCartFromWishlist,
     AddProductToWishlist,
     SelectProductFilterOption,
+    CheckVisibilityInHome,
 );

--- a/src/tasks/shop-customer/Listing/CheckVisibilityInHome.ts
+++ b/src/tasks/shop-customer/Listing/CheckVisibilityInHome.ts
@@ -1,0 +1,24 @@
+import { test as base } from '@playwright/test';
+import type { Task } from '../../../types/Task';
+import type { FixtureTypes} from '../../../types/FixtureTypes';
+
+export const CheckVisibilityInHome = base.extend<{ CheckVisibilityInHome: Task } & FixtureTypes>({
+    CheckVisibilityInHome: async ({ ShopCustomer, StorefrontHome, TestDataService }, use) => {
+        const task = (productName: string) => {
+            return async function CheckVisibilityInHome() {
+
+                await TestDataService.clearCaches();
+                const productLocators = await StorefrontHome.getListingItemByProductName(productName);
+
+                await ShopCustomer.expects(async () => {
+                    await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+                    await ShopCustomer.expects(productLocators.productName).toBeVisible();
+                }).toPass({
+                    intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+                });
+            }
+        };
+
+        await use(task);
+    },
+});

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -30,8 +30,7 @@ test('Storefront page objects', async ({
     await TestDataService.assignProductCategory(product.id, category.id);
 
     await ShopCustomer.goesTo(StorefrontHome.url())
-    await ShopCustomer.expects(StorefrontHome.categoryTitle).toBeVisible();
-    await CheckVisibilityInHome(product)();
+    await ShopCustomer.attemptsTo(CheckVisibilityInHome(product.name));
 
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
     await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -21,11 +21,17 @@ test('Storefront page objects', async ({
     StorefrontSearch,
     TestDataService,
     InstanceMeta,
+    CheckVisibilityInHome,
+    StorefrontHome,
 }) => {
 
     const product = await TestDataService.createBasicProduct();
     const category = await TestDataService.createCategory();
     await TestDataService.assignProductCategory(product.id, category.id);
+
+    await ShopCustomer.goesTo(StorefrontHome.url())
+    await ShopCustomer.expects(StorefrontHome.categoryTitle).toBeVisible();
+    await CheckVisibilityInHome(product)();
 
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
     await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();


### PR DESCRIPTION
Problem:
The current problem is that we dont have a possibility to check products on their visibility in storefront product listing if the cache is enabled, like in cloud environments.

Solution:
With the task `CheckVisibilityInHome` we have the possibility in Storefront to check for a product as long as the delayed cache is renewed. The task retries after 1 second, then every 2.5 seconds, until the assertion passes, as long as the global timeout has not been reached.