### PR TITLE
feat: refactor token management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [11.34.0](https://github.com/shopware/acceptance-test-suite/compare/v11.33.2...v11.34.0) (2025-10-08)
+
+
+### Features
+
+* add sales channel detail page ([#431](https://github.com/shopware/acceptance-test-suite/issues/431)) ([3ed4da0](https://github.com/shopware/acceptance-test-suite/commit/3ed4da0dba307ebb6b99a108b00526ade130b1e1))
+* task check visibility of products ([#495](https://github.com/shopware/acceptance-test-suite/issues/495)) ([ddfc1b6](https://github.com/shopware/acceptance-test-suite/commit/ddfc1b6b423bcc173ca4dd3949c70d1b15235dc4))
+
+
+### Bug Fixes
+
+* add token assertion ([#496](https://github.com/shopware/acceptance-test-suite/issues/496)) ([45b0c9e](https://github.com/shopware/acceptance-test-suite/commit/45b0c9e0def3dc308d1262b9e3a16e412437ec10))
+
 ## [11.33.2](https://github.com/shopware/acceptance-test-suite/compare/v11.33.1...v11.33.2) (2025-10-06)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "11.33.2",
+  "version": "11.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shopware-ag/acceptance-test-suite",
-      "version": "11.33.2",
+      "version": "11.34.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/acceptance-test-suite",
-  "version": "11.33.2",
+  "version": "11.34.0",
   "description": "Shopware Acceptance Test Suite",
   "author": "shopware AG",
   "license": "MIT",

--- a/src/fixtures/ApiContexts.ts
+++ b/src/fixtures/ApiContexts.ts
@@ -16,6 +16,7 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
         async ({ }, use) => {
             const adminApiContext = await AdminApiContext.create();
             await use(adminApiContext);
+            await adminApiContext.dispose();
         },
         { scope: 'worker' },
     ],

--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -1,139 +1,90 @@
 import { request } from '@playwright/test';
-import type { APIRequestContext, APIResponse } from 'playwright-core';
-import { TokenManager, AdminApiAuthOptions } from './TokenManager';
+import { TokenManager, AuthOptions } from './TokenManager';
 
-type HTTPHeaders = Record<string, string>;
-
-interface RequestOptions<PAYLOAD> {
-    [key: string]: unknown;
-    data?: PAYLOAD;
-    headers?: HTTPHeaders;
-}
-
-export interface AdminApiContextOptions extends AdminApiAuthOptions {
-    default_headers?: HTTPHeaders;
+export interface AdminApiContextOptions extends AuthOptions {
+    default_headers?: Record<string, string>;
     ignoreHTTPSErrors?: boolean;
-    max_retries?: number; // for idempotent methods; default 2
+    max_retries?: number;
+    retry_base_ms?: number;
 }
-
-type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
 export class AdminApiContext {
-    private context: APIRequestContext;
-    private options: AdminApiContextOptions;
-    private tokenManager: TokenManager;
+    private readonly options: AdminApiContextOptions;
+    private readonly tokenManager: TokenManager;
+    private ctx!: any;
 
-    private static readonly defaultOptions: AdminApiContextOptions = {
-        app_url: process.env['ADMIN_API_URL'] || process.env['APP_URL'] || '',
-        client_id: process.env['SHOPWARE_ACCESS_KEY_ID'],
-        client_secret: process.env['SHOPWARE_SECRET_ACCESS_KEY'],
-        admin_username: process.env['SHOPWARE_ADMIN_USERNAME'] || 'admin',
-        admin_password: process.env['SHOPWARE_ADMIN_PASSWORD'] || 'shopware',
-        ignoreHTTPSErrors: true,
-        max_retries: 2,
-    };
-
-    private constructor(context: APIRequestContext, options: AdminApiContextOptions) {
-        this.context = context;
+    private constructor(options: AdminApiContextOptions) {
         this.options = options;
-        this.tokenManager = new TokenManager({
-            app_url: options.app_url,
-            token_endpoint: options.token_endpoint,
-            client_id: options.client_id,
-            client_secret: options.client_secret,
-            admin_username: options.admin_username,
-            admin_password: options.admin_password,
-            scope: options.scope,
-            access_token: options.access_token,
-            refresh_token: options.refresh_token,
-            expires_in: options.expires_in,
-        });
+        this.tokenManager = TokenManager.create(options);
     }
 
-    /** Factory used by the ApiContexts.ts fixture */
-    static async create(baseUrl?: string, overrides?: Partial<AdminApiContextOptions>): Promise<AdminApiContext> {
-        const merged: AdminApiContextOptions = {
-            ...AdminApiContext.defaultOptions,
-            ...(overrides ?? {}),
-            app_url: (baseUrl || overrides?.app_url || AdminApiContext.defaultOptions.app_url || '').replace(/\/$/, ''),
+    /** Create from explicit options */
+    static async create(options?: Partial<AdminApiContextOptions>): Promise<AdminApiContext> {
+        const defaults: AdminApiContextOptions = {
+            app_url: process.env.APP_URL!,
+            client_id: process.env.ADMIN_CLIENT_ID,
+            client_secret: process.env.ADMIN_CLIENT_SECRET,
+            admin_username: process.env.ADMIN_USERNAME,
+            admin_password: process.env.ADMIN_PASSWORD,
+            scope: process.env.ADMIN_SCOPE,
+            default_headers: { 'x-requested-with': 'playwright-tests' },
+            ignoreHTTPSErrors: true,
+            max_retries: 2,
+            retry_base_ms: 200,
         };
 
-        const ctx = await request.newContext({
-            baseURL: merged.app_url,
-            ignoreHTTPSErrors: merged.ignoreHTTPSErrors ?? true,
-            extraHTTPHeaders: merged.default_headers ?? {},
+        const merged = { ...defaults, ...(options ?? {}) };
+        const ctx = new AdminApiContext(merged);
+        await ctx.init();
+        return ctx;
+    }
+
+    private async init() {
+        this.ctx = await request.newContext({
+            baseURL: this.options.app_url.replace(/\/+$/, ''),
+            extraHTTPHeaders: this.options.default_headers,
+            ignoreHTTPSErrors: this.options.ignoreHTTPSErrors ?? true,
         });
-
-        return new AdminApiContext(ctx, merged);
     }
 
-    async dispose(): Promise<void> {
-        await this.context.dispose();
+    async dispose() {
+        await this.ctx.dispose();
     }
 
-    // Convenience verbs
-    get<P = unknown>(url: string, options?: RequestOptions<P>)    { return this.request<P>('get', url, options); }
-    post<P = unknown>(url: string, options?: RequestOptions<P>)   { return this.request<P>('post', url, options); }
-    put<P = unknown>(url: string, options?: RequestOptions<P>)    { return this.request<P>('put', url, options); }
-    patch<P = unknown>(url: string, options?: RequestOptions<P>)  { return this.request<P>('patch', url, options); }
-    delete<P = unknown>(url: string, options?: RequestOptions<P>) { return this.request<P>('delete', url, options); }
+    // --- simple convenience methods ---
+    get(url: string, opt: any = {}) { return this.send('GET', url, opt); }
+    post(url: string, opt: any = {}) { return this.send('POST', url, opt); }
+    put(url: string, opt: any = {}) { return this.send('PUT', url, opt); }
+    patch(url: string, opt: any = {}) { return this.send('PATCH', url, opt); }
+    delete(url: string, opt: any = {}) { return this.send('DELETE', url, opt); }
 
-    /** Core request with auth, 401-aware retry, and bounded backoff for 429/5xx. */
-    async request<PAYLOAD = unknown>(
-        method: HttpMethod,
-        url: string,
-        options?: RequestOptions<PAYLOAD>,
-    ): Promise<APIResponse> {
-        const call = async (): Promise<APIResponse> => {
-            const token = await this.tokenManager.getValidAccessToken();
-            const headers: HTTPHeaders = {
-                ...(this.options.default_headers ?? {}),
-                ...(options?.headers ?? {}),
+    private async send(method: string, url: string, opt: any) {
+        const token = await this.tokenManager.getValidAccessToken();
+        const res = await this.ctx.fetch(url, {
+            method,
+            data: opt.data,
+            headers: {
                 Authorization: `Bearer ${token}`,
-            };
-            const reqOpts = { ...options, headers };
-            return (this.context as any)[method](url, reqOpts);
-        };
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                ...(opt.headers ?? {}),
+            },
+        });
 
-        let response = await call();
-
-        if (response.status() === 401) {
-            // Token likely expired/revoked. Force refresh and retry once.
+        if (res.status() === 401 || res.status() === 403) {
             await this.tokenManager.forceRefresh();
-            response = await call();
+            return this.ctx.fetch(url, {
+                method,
+                data: opt.data,
+                headers: {
+                    Authorization: `Bearer ${await this.tokenManager.getValidAccessToken()}`,
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    ...(opt.headers ?? {}),
+                },
+            });
         }
 
-        if (this.isTransient(response.status())) {
-            response = await this.retryWithBackoff(method, url, options, call);
-        }
-
-        return response;
-    }
-
-    private isTransient(status: number): boolean {
-        return status === 429 || (status >= 500 && status <= 599);
-    }
-
-    private isIdempotent(method: HttpMethod): boolean {
-        return method === 'get' || method === 'delete';
-    }
-
-    private async retryWithBackoff<P>(
-        method: HttpMethod,
-        url: string,
-        options: RequestOptions<P> | undefined,
-        call: () => Promise<APIResponse>,
-    ): Promise<APIResponse> {
-        const maxRetries = this.isIdempotent(method) ? (this.options.max_retries ?? 2) : Math.min(this.options.max_retries ?? 0, 2);
-        let attempt = 0;
-        let res = await call();
-        while (this.isTransient(res.status()) && attempt < maxRetries) {
-            const base = 200;
-            const delay = Math.min(2000, base * Math.pow(2, attempt)) + Math.floor(Math.random() * 100);
-            await new Promise(r => setTimeout(r, delay));
-            res = await call();
-            attempt++;
-        }
         return res;
     }
 }

--- a/src/services/AdminApiContext.ts
+++ b/src/services/AdminApiContext.ts
@@ -1,194 +1,139 @@
-import { expect, request } from '@playwright/test';
+import { request } from '@playwright/test';
 import type { APIRequestContext, APIResponse } from 'playwright-core';
+import { TokenManager, AdminApiAuthOptions } from './TokenManager';
 
 type HTTPHeaders = Record<string, string>;
 
 interface RequestOptions<PAYLOAD> {
     [key: string]: unknown;
     data?: PAYLOAD;
+    headers?: HTTPHeaders;
 }
 
-export interface AdminApiContextOptions {
-    app_url?: string;
-    client_id?: string;
-    client_secret?: string;
-    access_token?: string;
-    admin_username?: string;
-    admin_password?: string;
+export interface AdminApiContextOptions extends AdminApiAuthOptions {
+    default_headers?: HTTPHeaders;
     ignoreHTTPSErrors?: boolean;
+    max_retries?: number; // for idempotent methods; default 2
 }
+
+type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
 export class AdminApiContext {
-
-    public context: APIRequestContext;
-    public readonly options: AdminApiContextOptions;
+    private context: APIRequestContext;
+    private options: AdminApiContextOptions;
+    private tokenManager: TokenManager;
 
     private static readonly defaultOptions: AdminApiContextOptions = {
-        app_url: process.env['ADMIN_API_URL'] || process.env['APP_URL'],
+        app_url: process.env['ADMIN_API_URL'] || process.env['APP_URL'] || '',
         client_id: process.env['SHOPWARE_ACCESS_KEY_ID'],
         client_secret: process.env['SHOPWARE_SECRET_ACCESS_KEY'],
         admin_username: process.env['SHOPWARE_ADMIN_USERNAME'] || 'admin',
         admin_password: process.env['SHOPWARE_ADMIN_PASSWORD'] || 'shopware',
         ignoreHTTPSErrors: true,
+        max_retries: 2,
     };
 
-    constructor(context: APIRequestContext, options: AdminApiContextOptions) {
+    private constructor(context: APIRequestContext, options: AdminApiContextOptions) {
         this.context = context;
         this.options = options;
+        this.tokenManager = new TokenManager({
+            app_url: options.app_url,
+            token_endpoint: options.token_endpoint,
+            client_id: options.client_id,
+            client_secret: options.client_secret,
+            admin_username: options.admin_username,
+            admin_password: options.admin_password,
+            scope: options.scope,
+            access_token: options.access_token,
+            refresh_token: options.refresh_token,
+            expires_in: options.expires_in,
+        });
     }
 
-    public static async create(options?: AdminApiContextOptions) {
-        const contextOptions = { ...this.defaultOptions, ...options };
-
-        const tmpContext = await this.createApiRequestContext(contextOptions);
-
-        if (!contextOptions.client_id) {
-            contextOptions['access_token'] = await this.authenticateWithUserPassword(tmpContext, contextOptions);
-
-            const userContext = await this.createApiRequestContext(contextOptions);
-            const accessKeyData = await (await userContext.get('_action/access-key/intergration')).json() as { accessKey: string, secretAccessKey: string };
-
-            const integrationData = {
-                admin: true,
-                label: 'Playwright Acceptance Test Suite',
-                ...accessKeyData,
-            };
-
-            await userContext.post('integration', {
-                data: integrationData,
-            });
-
-            contextOptions.client_id = accessKeyData.accessKey;
-            contextOptions.client_secret = accessKeyData.secretAccessKey;
-        }
-
-        contextOptions['access_token'] = await this.authenticateWithClientCredentials(tmpContext, contextOptions);
-        return new AdminApiContext(await this.createApiRequestContext(contextOptions), contextOptions);
-    }
-
-    private static async createApiRequestContext(options: AdminApiContextOptions): Promise<APIRequestContext> {
-        const extraHTTPHeaders: HTTPHeaders = {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
+    /** Factory used by the ApiContexts.ts fixture */
+    static async create(baseUrl?: string, overrides?: Partial<AdminApiContextOptions>): Promise<AdminApiContext> {
+        const merged: AdminApiContextOptions = {
+            ...AdminApiContext.defaultOptions,
+            ...(overrides ?? {}),
+            app_url: (baseUrl || overrides?.app_url || AdminApiContext.defaultOptions.app_url || '').replace(/\/$/, ''),
         };
 
-        if (options.access_token && options.access_token.length) {
-            extraHTTPHeaders['Authorization'] = 'Bearer ' + options.access_token;
-        }
-
-        return await request.newContext({
-            baseURL: `${options.app_url}api/`,
-            ignoreHTTPSErrors: options.ignoreHTTPSErrors,
-            extraHTTPHeaders,
-        });
-    }
-
-    static async authenticateWithClientCredentials(context: APIRequestContext, options: AdminApiContextOptions) {
-        const authResponse: APIResponse = await context.post('oauth/token', {
-            data: {
-                grant_type: 'client_credentials',
-                client_id: options.client_id,
-                client_secret: options.client_secret,
-                scope: 'write',
-            },
+        const ctx = await request.newContext({
+            baseURL: merged.app_url,
+            ignoreHTTPSErrors: merged.ignoreHTTPSErrors ?? true,
+            extraHTTPHeaders: merged.default_headers ?? {},
         });
 
-        const authData = (await authResponse.json()) as { access_token?: string };
-
-        expect(authResponse.ok(), 'Should authenticate with client credentials').toBeTruthy();
-
-        if (!authData['access_token']) {
-            throw new Error(`Failed to authenticate with client_id: ${options.client_id}`);
-        }
-
-        return authData['access_token'];
+        return new AdminApiContext(ctx, merged);
     }
 
-    static async authenticateWithUserPassword(context: APIRequestContext, options: AdminApiContextOptions) {
-        const authResponse: APIResponse = await context.post('oauth/token', {
-            data: {
-                client_id: 'administration',
-                grant_type: 'password',
-                username: options.admin_username,
-                password: options.admin_password,
-                scope: 'write',
-            },
-        });
-
-        const authData = (await authResponse.json()) as { access_token?: string };
-
-        expect(authResponse.ok(), 'Should authenticate with user credentials').toBeTruthy();
-
-        if (!authData['access_token']) {
-            throw new Error(`Failed to authenticate with user: ${options.admin_username}`);
-        }
-
-        return authData['access_token'];
+    async dispose(): Promise<void> {
+        await this.context.dispose();
     }
 
-    isAuthenticated(): boolean {
-        // TODO: check token expiry
-        return !!this.options['access_token'];
-    }
+    // Convenience verbs
+    get<P = unknown>(url: string, options?: RequestOptions<P>)    { return this.request<P>('get', url, options); }
+    post<P = unknown>(url: string, options?: RequestOptions<P>)   { return this.request<P>('post', url, options); }
+    put<P = unknown>(url: string, options?: RequestOptions<P>)    { return this.request<P>('put', url, options); }
+    patch<P = unknown>(url: string, options?: RequestOptions<P>)  { return this.request<P>('patch', url, options); }
+    delete<P = unknown>(url: string, options?: RequestOptions<P>) { return this.request<P>('delete', url, options); }
 
-    async refreshAccessToken(): Promise<void> {
-        this.options['access_token'] = await AdminApiContext.authenticateWithClientCredentials(this.context, this.options);
-        this.context = await AdminApiContext.createApiRequestContext(this.options);
-    }
-
-    async get<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('get', url, options);
-    }
-
-    async post<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('post', url, options);
-    }
-
-    async patch<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('patch', url, options);
-    }
-
-    async delete<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('delete', url, options);
-    }
-
-    async fetch<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('fetch', url, options);
-    }
-
-    async head<PAYLOAD>(url: string, options?: RequestOptions<PAYLOAD>): Promise<APIResponse> {
-        return this.handleRequest('head', url, options);
-    }
-
-    private async handleRequest<PAYLOAD>(
-      method: 'get' | 'post' | 'patch' | 'delete' | 'fetch' | 'head',
-      url: string,
-      options?: RequestOptions<PAYLOAD>,
+    /** Core request with auth, 401-aware retry, and bounded backoff for 429/5xx. */
+    async request<PAYLOAD = unknown>(
+        method: HttpMethod,
+        url: string,
+        options?: RequestOptions<PAYLOAD>,
     ): Promise<APIResponse> {
-        const methodMap = {
-            get: this.context.get.bind(this.context),
-            post: this.context.post.bind(this.context),
-            patch: this.context.patch.bind(this.context),
-            delete: this.context.delete.bind(this.context),
-            fetch: this.context.fetch.bind(this.context),
-            head: this.context.head.bind(this.context),
+        const call = async (): Promise<APIResponse> => {
+            const token = await this.tokenManager.getValidAccessToken();
+            const headers: HTTPHeaders = {
+                ...(this.options.default_headers ?? {}),
+                ...(options?.headers ?? {}),
+                Authorization: `Bearer ${token}`,
+            };
+            const reqOpts = { ...options, headers };
+            return (this.context as any)[method](url, reqOpts);
         };
 
-        let response = await methodMap[method](url, options);
+        let response = await call();
 
         if (response.status() === 401) {
-            await this.refreshAccessToken();
-            const updatedOptions: RequestOptions<PAYLOAD> = {
-                ...options,
-                data: options?.data ?? undefined,
-                headers: {
-                    ...(options?.headers || {}),
-                    Authorization: `Bearer ${this.options['access_token']}`,
-                },
-            };
-            response = await methodMap[method](url, updatedOptions);
+            // Token likely expired/revoked. Force refresh and retry once.
+            await this.tokenManager.forceRefresh();
+            response = await call();
+        }
+
+        if (this.isTransient(response.status())) {
+            response = await this.retryWithBackoff(method, url, options, call);
         }
 
         return response;
+    }
+
+    private isTransient(status: number): boolean {
+        return status === 429 || (status >= 500 && status <= 599);
+    }
+
+    private isIdempotent(method: HttpMethod): boolean {
+        return method === 'get' || method === 'delete';
+    }
+
+    private async retryWithBackoff<P>(
+        method: HttpMethod,
+        url: string,
+        options: RequestOptions<P> | undefined,
+        call: () => Promise<APIResponse>,
+    ): Promise<APIResponse> {
+        const maxRetries = this.isIdempotent(method) ? (this.options.max_retries ?? 2) : Math.min(this.options.max_retries ?? 0, 2);
+        let attempt = 0;
+        let res = await call();
+        while (this.isTransient(res.status()) && attempt < maxRetries) {
+            const base = 200;
+            const delay = Math.min(2000, base * Math.pow(2, attempt)) + Math.floor(Math.random() * 100);
+            await new Promise(r => setTimeout(r, delay));
+            res = await call();
+            attempt++;
+        }
+        return res;
     }
 }

--- a/src/services/TokenManager.ts
+++ b/src/services/TokenManager.ts
@@ -1,5 +1,10 @@
 import { request } from '@playwright/test';
 
+/**
+ * Auth options for Admin API.
+ * Provide either a refresh_token or admin credentials so we can reauthenticate
+ * if the refresh token becomes invalid.
+ */
 export interface AdminApiAuthOptions {
     app_url: string;
     token_endpoint?: string; // default '/oauth/token'
@@ -14,51 +19,38 @@ export interface AdminApiAuthOptions {
     expires_in?: number; // seconds
 }
 
-type TokenResponse = {
-    access_token: string;
-    token_type?: string;
-    expires_in?: number;
-    refresh_token?: string;
-    scope?: string;
-};
-
-export class TokenEndpointError extends Error {
-    status: number;
-    data: any;
-    constructor(message: string, status: number, data: any) {
-        super(message);
-        this.name = 'TokenEndpointError';
-        this.status = status;
-        this.data = data;
-    }
-}
-
+/**
+ * A tiny, robust token manager with built-in reauth fallback.
+ * - Uses a single-flight lock to avoid concurrent refresh storms.
+ * - If refresh fails with invalid_grant/401, falls back to password grant.
+ * - Adds a safety window to account for clock skew.
+ */
 export class TokenManager {
+    private readonly opts: AdminApiAuthOptions;
     private accessToken?: string;
     private refreshToken?: string;
     private expiresAt?: number; // epoch ms
-    private inFlight?: Promise<void>;
-    private readonly skewMs = 60_000;
+    private inflight?: Promise<void>; // single-flight
 
-    private readonly opts: AdminApiAuthOptions;
-    private readonly appUrl: string;
-    private readonly tokenEndpoint: string;
+    private static readonly SKEW_MS = 60_000; // 60s safety window
 
     constructor(opts: AdminApiAuthOptions) {
         this.opts = opts;
-        this.appUrl = opts.app_url.replace(/\/$/, '');
-        this.tokenEndpoint = opts.token_endpoint ?? 'oauth/token';
-
         if (opts.access_token) this.accessToken = opts.access_token;
         if (opts.refresh_token) this.refreshToken = opts.refresh_token;
-        if (opts.expires_in) this.expiresAt = Date.now() + opts.expires_in * 1000;
+        if (opts.expires_in) this.setExpiryFromNow(opts.expires_in);
+    }
+
+    static create(opts: AdminApiAuthOptions) {
+        return new TokenManager(opts);
     }
 
     async getValidAccessToken(): Promise<string> {
         if (!this.accessToken || this.isExpiring()) {
             await this.refreshWithLock();
         }
-        return this.accessToken!;
+        if (!this.accessToken) throw new Error('No access token available after refresh.');
+        return this.accessToken;
     }
 
     async forceRefresh(): Promise<void> {
@@ -67,97 +59,107 @@ export class TokenManager {
 
     private isExpiring(): boolean {
         if (!this.expiresAt) return true;
-        return Date.now() >= this.expiresAt - this.skewMs;
+        return Date.now() >= this.expiresAt - TokenManager.SKEW_MS;
+    }
+
+    private setExpiryFromNow(expiresInSeconds: number) {
+        this.expiresAt = Date.now() + Math.max(0, expiresInSeconds) * 1000;
     }
 
     private async refreshWithLock(force = false): Promise<void> {
-        if (!this.inFlight) {
-            this.inFlight = (async () => {
-                await this.refreshOrReauth(force);
-            })().finally(() => (this.inFlight = undefined));
-        }
-        return this.inFlight;
-    }
-
-    private async refreshOrReauth(force: boolean): Promise<void> {
-        if (!force && this.refreshToken) {
+        if (this.inflight) return this.inflight;
+        this.inflight = (async () => {
             try {
-                await this.tryRefresh();
-                return;
-            } catch (err) {
-                if (!this.isInvalidGrant(err)) throw err;
-                // else fall through to reauth
+                if (!force && this.refreshToken) {
+                    const ok = await this.tryRefreshGrant();
+                    if (ok) return;
+                }
+                await this.passwordGrant(); // fallback (reauthenticate)
+            } finally {
+                this.inflight = undefined;
             }
-        }
-        await this.fullReauth();
+        })();
+        return this.inflight;
     }
 
-    private isInvalidGrant(err: any): boolean {
-        const status = err?.status;
-        const code = err?.data?.error;
-        return status === 400 || status === 401 || code === 'invalid_grant';
-    }
-
-    private async tryRefresh(): Promise<void> {
-        const form: Record<string, string> = {
-            grant_type: 'refresh_token',
-            refresh_token: this.refreshToken!,
-        };
-        if (this.opts.client_id) form['client_id'] = this.opts.client_id;
-        if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
-        const res = await this.tokenRequest(form);
-        this.setTokens(res);
-    }
-
-    private async fullReauth(): Promise<void> {
-        const hasClientCreds =
-            !!(this.opts.client_id && this.opts.client_secret && !this.opts.admin_username && !this.opts.admin_password);
-
-        let form: Record<string, string>;
-        if (hasClientCreds) {
-            form = { grant_type: 'client_credentials' };
-            if (this.opts.client_id) form['client_id'] = this.opts.client_id;
-            if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
-            if (this.opts.scope) form['scope'] = this.opts.scope;
-        } else {
-            form = {
-                grant_type: 'password',
-                username: String(this.opts.admin_username ?? ''),
-                password: String(this.opts.admin_password ?? ''),
-            };
-            if (this.opts.client_id) form['client_id'] = this.opts.client_id;
-            if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
-            if (this.opts.scope) form['scope'] = this.opts.scope;
-        }
-
-        const res = await this.tokenRequest(form);
-        this.setTokens(res);
-    }
-
-    private setTokens(res: TokenResponse) {
-        this.accessToken = res.access_token;
-        if (res.refresh_token) this.refreshToken = res.refresh_token;
-        const ttl = (res.expires_in ?? 300) * 1000;
-        this.expiresAt = Date.now() + ttl;
-    }
-
-    private async tokenRequest(form: Record<string, string>): Promise<TokenResponse> {
-        const ctx = await request.newContext({
-            baseURL: this.appUrl,
-            extraHTTPHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        });
-        const resp = await ctx.post(this.tokenEndpoint, { form });
-        if (!resp.ok()) {
-            let data: any = null;
-            try {
-                data = await resp.json();
-            } catch {}
-            throw new TokenEndpointError(
-                `Token endpoint failed: ${resp.status()} ${resp.statusText()}`,
-                resp.status(),
-                data,
+    private async tryRefreshGrant(): Promise<boolean> {
+        try {
+            const res = await request.newContext().then(ctx =>
+                ctx.post(this.tokenUrl(), {
+                    data: {
+                        grant_type: 'refresh_token',
+                        refresh_token: this.refreshToken,
+                        client_id: this.opts.client_id,
+                        client_secret: this.opts.client_secret,
+                    },
+                    ignoreHTTPSErrors: true,
+                }).finally(() => ctx.dispose()),
             );
+
+            if (!res.ok()) {
+                // Common failure when refresh token is invalid/expired
+                const status = res.status();
+                const body = await safeText(res);
+                if (status === 400 || status === 401) return false;
+                throw new Error(`Refresh token request failed (${status}): ${body}`);
+            }
+
+            const json = await res.json();
+            this.accessToken = json.access_token;
+            this.refreshToken = json.refresh_token ?? this.refreshToken;
+            this.setExpiryFromNow(json.expires_in ?? 300);
+            return true;
+        } catch {
+            // Network or other failure → caller decides fallback
+            return false;
         }
-        return (await resp.json()) as TokenResponse;
+    }
+
+    private async passwordGrant(): Promise<void> {
+        if (!this.opts.admin_username || !this.opts.admin_password) {
+            throw new Error('Refresh failed and no credentials provided to reauthenticate.');
+        }
+        const ctx = await request.newContext();
+        try {
+            const res = await ctx.post(this.tokenUrl(), {
+                data: {
+                    grant_type: 'password',
+                    username: this.opts.admin_username,
+                    password: this.opts.admin_password,
+                    client_id: this.opts.client_id,
+                    client_secret: this.opts.client_secret,
+                    scope: this.opts.scope,
+                },
+                ignoreHTTPSErrors: true,
+            });
+
+            if (!res.ok()) {
+                const body = await safeText(res);
+                throw new Error(`Password grant failed (${res.status()}): ${body}`);
+            }
+
+            const json = await res.json();
+            this.accessToken = json.access_token;
+            this.refreshToken = json.refresh_token;
+            this.setExpiryFromNow(json.expires_in ?? 300);
+        } finally {
+            await ctx.dispose();
+        }
+    }
+
+    private tokenUrl(): string {
+        const base = this.opts.app_url.replace(/\/+$/, '');
+        const endpoint = (this.opts.token_endpoint ?? 'oauth/token').replace(/^\/?/, '/');
+        return `${base}${endpoint}`;
     }
 }
+
+async function safeText(res: any): Promise<string> {
+    try {
+        return await res.text();
+    } catch {
+        return '';
+    }
+}
+
+export type { AdminApiAuthOptions as AuthOptions };

--- a/src/services/TokenManager.ts
+++ b/src/services/TokenManager.ts
@@ -1,0 +1,163 @@
+import { request } from '@playwright/test';
+
+export interface AdminApiAuthOptions {
+    app_url: string;
+    token_endpoint?: string; // default '/oauth/token'
+    client_id?: string;
+    client_secret?: string;
+    admin_username?: string;
+    admin_password?: string;
+    scope?: string;
+
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number; // seconds
+}
+
+type TokenResponse = {
+    access_token: string;
+    token_type?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    scope?: string;
+};
+
+export class TokenEndpointError extends Error {
+    status: number;
+    data: any;
+    constructor(message: string, status: number, data: any) {
+        super(message);
+        this.name = 'TokenEndpointError';
+        this.status = status;
+        this.data = data;
+    }
+}
+
+export class TokenManager {
+    private accessToken?: string;
+    private refreshToken?: string;
+    private expiresAt?: number; // epoch ms
+    private inFlight?: Promise<void>;
+    private readonly skewMs = 60_000;
+
+    private readonly opts: AdminApiAuthOptions;
+    private readonly appUrl: string;
+    private readonly tokenEndpoint: string;
+
+    constructor(opts: AdminApiAuthOptions) {
+        this.opts = opts;
+        this.appUrl = opts.app_url.replace(/\/$/, '');
+        this.tokenEndpoint = opts.token_endpoint ?? 'oauth/token';
+
+        if (opts.access_token) this.accessToken = opts.access_token;
+        if (opts.refresh_token) this.refreshToken = opts.refresh_token;
+        if (opts.expires_in) this.expiresAt = Date.now() + opts.expires_in * 1000;
+    }
+
+    async getValidAccessToken(): Promise<string> {
+        if (!this.accessToken || this.isExpiring()) {
+            await this.refreshWithLock();
+        }
+        return this.accessToken!;
+    }
+
+    async forceRefresh(): Promise<void> {
+        await this.refreshWithLock(true);
+    }
+
+    private isExpiring(): boolean {
+        if (!this.expiresAt) return true;
+        return Date.now() >= this.expiresAt - this.skewMs;
+    }
+
+    private async refreshWithLock(force = false): Promise<void> {
+        if (!this.inFlight) {
+            this.inFlight = (async () => {
+                await this.refreshOrReauth(force);
+            })().finally(() => (this.inFlight = undefined));
+        }
+        return this.inFlight;
+    }
+
+    private async refreshOrReauth(force: boolean): Promise<void> {
+        if (!force && this.refreshToken) {
+            try {
+                await this.tryRefresh();
+                return;
+            } catch (err) {
+                if (!this.isInvalidGrant(err)) throw err;
+                // else fall through to reauth
+            }
+        }
+        await this.fullReauth();
+    }
+
+    private isInvalidGrant(err: any): boolean {
+        const status = err?.status;
+        const code = err?.data?.error;
+        return status === 400 || status === 401 || code === 'invalid_grant';
+    }
+
+    private async tryRefresh(): Promise<void> {
+        const form: Record<string, string> = {
+            grant_type: 'refresh_token',
+            refresh_token: this.refreshToken!,
+        };
+        if (this.opts.client_id) form['client_id'] = this.opts.client_id;
+        if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
+        const res = await this.tokenRequest(form);
+        this.setTokens(res);
+    }
+
+    private async fullReauth(): Promise<void> {
+        const hasClientCreds =
+            !!(this.opts.client_id && this.opts.client_secret && !this.opts.admin_username && !this.opts.admin_password);
+
+        let form: Record<string, string>;
+        if (hasClientCreds) {
+            form = { grant_type: 'client_credentials' };
+            if (this.opts.client_id) form['client_id'] = this.opts.client_id;
+            if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
+            if (this.opts.scope) form['scope'] = this.opts.scope;
+        } else {
+            form = {
+                grant_type: 'password',
+                username: String(this.opts.admin_username ?? ''),
+                password: String(this.opts.admin_password ?? ''),
+            };
+            if (this.opts.client_id) form['client_id'] = this.opts.client_id;
+            if (this.opts.client_secret) form['client_secret'] = this.opts.client_secret;
+            if (this.opts.scope) form['scope'] = this.opts.scope;
+        }
+
+        const res = await this.tokenRequest(form);
+        this.setTokens(res);
+    }
+
+    private setTokens(res: TokenResponse) {
+        this.accessToken = res.access_token;
+        if (res.refresh_token) this.refreshToken = res.refresh_token;
+        const ttl = (res.expires_in ?? 300) * 1000;
+        this.expiresAt = Date.now() + ttl;
+    }
+
+    private async tokenRequest(form: Record<string, string>): Promise<TokenResponse> {
+        const ctx = await request.newContext({
+            baseURL: this.appUrl,
+            extraHTTPHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        });
+        const resp = await ctx.post(this.tokenEndpoint, { form });
+        if (!resp.ok()) {
+            let data: any = null;
+            try {
+                data = await resp.json();
+            } catch {}
+            throw new TokenEndpointError(
+                `Token endpoint failed: ${resp.status()} ${resp.statusText()}`,
+                resp.status(),
+                data,
+            );
+        }
+        return (await resp.json()) as TokenResponse;
+    }
+}

--- a/src/tasks/shop-customer-tasks.ts
+++ b/src/tasks/shop-customer-tasks.ts
@@ -27,6 +27,7 @@ import { SearchForTerm } from './shop-customer/Search/SearchForTerm';
 import { ValidateAccessibility } from './shop-customer/Accessibility/ValidateAccessibility';
 import { AddProductToCartFromWishlist, AddProductToWishlist, RemoveProductFromWishlist } from './shop-customer/Wishlist/WishlistActions';
 import { SelectProductFilterOption } from './shop-customer/Product/SelectProductFilterOption';
+import { CheckVisibilityInHome } from './shop-customer/Listing/CheckVisibilityInHome';
 
 export const test = mergeTests(
     Login,
@@ -54,4 +55,5 @@ export const test = mergeTests(
     AddProductToCartFromWishlist,
     AddProductToWishlist,
     SelectProductFilterOption,
+    CheckVisibilityInHome,
 );

--- a/src/tasks/shop-customer/Listing/CheckVisibilityInHome.ts
+++ b/src/tasks/shop-customer/Listing/CheckVisibilityInHome.ts
@@ -1,0 +1,24 @@
+import { test as base } from '@playwright/test';
+import type { Task } from '../../../types/Task';
+import type { FixtureTypes} from '../../../types/FixtureTypes';
+
+export const CheckVisibilityInHome = base.extend<{ CheckVisibilityInHome: Task } & FixtureTypes>({
+    CheckVisibilityInHome: async ({ ShopCustomer, StorefrontHome, TestDataService }, use) => {
+        const task = (productName: string) => {
+            return async function CheckVisibilityInHome() {
+
+                await TestDataService.clearCaches();
+                const productLocators = await StorefrontHome.getListingItemByProductName(productName);
+
+                await ShopCustomer.expects(async () => {
+                    await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+                    await ShopCustomer.expects(productLocators.productName).toBeVisible();
+                }).toPass({
+                    intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+                });
+            }
+        };
+
+        await use(task);
+    },
+});

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -21,11 +21,16 @@ test('Storefront page objects', async ({
     StorefrontSearch,
     TestDataService,
     InstanceMeta,
+    CheckVisibilityInHome,
+    StorefrontHome,
 }) => {
 
     const product = await TestDataService.createBasicProduct();
     const category = await TestDataService.createCategory();
     await TestDataService.assignProductCategory(product.id, category.id);
+
+    await ShopCustomer.goesTo(StorefrontHome.url())
+    await ShopCustomer.attemptsTo(CheckVisibilityInHome(product.name));
 
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
     await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();


### PR DESCRIPTION
<html><head></head><body><h1>Make Admin API auth robust to invalid/expired refresh tokens &amp; concurrency</h1>
<p><strong>TL;DR:</strong> We centralized token management, added proactive + singleflight refresh, handled rotation, and made retries safe. The fixture entry point stays the same; reliability goes up.</p></body></html>
<h2>Why</h2>
<p>Intermittent <code inline="">401</code> errors occurred when the refresh token was invalid/expired/rotated. The previous logic:</p>
<ul>
<li>
<p>Retried once on <code inline="">401</code> without distinguishing resource vs token-endpoint failures.</p>
</li>
<li>
<p>Didn’t handle <strong>refresh token rotation</strong>.</p>
</li>
<li>
<p>Allowed <strong>multiple concurrent refreshes</strong> to race.</p>
</li>
<li>
<p>Waited for expiry (no clock-skew margin).</p>
</li>
<li>
<p>Lacked bounded backoff for <code inline="">429/5xx</code>.</p>
</li>
</ul>
<h2>What changed</h2>
<ul>
<li>
<p>Introduced <strong><code inline="">TokenManager</code></strong> to centralize token lifecycle:</p>
<ul>
<li>
<p><strong>Proactive refresh</strong> with a 60s skew.</p>
</li>
<li>
<p><strong>Singleflight lock</strong> so concurrent calls share one refresh.</p>
</li>
<li>
<p><strong>Refresh-token rotation</strong> support.</p>
</li>
<li>
<p><strong>Full re-auth fallback</strong> on <code inline="">invalid_grant</code> / <code inline="">400–401</code> from the token endpoint.</p>
</li>
</ul>
</li>
<li>
<p>Rewrote <strong><code inline="">AdminApiContext</code></strong> to use <code inline="">TokenManager</code>:</p>
<ul>
<li>
<p>Injects <code inline="">Authorization: Bearer &lt;token&gt;</code> for every call.</p>
</li>
<li>
<p>On <code inline="">401</code> from the resource: <strong>force refresh, retry once</strong>.</p>
</li>
<li>
<p><strong>Bounded exponential backoff</strong> for <code inline="">429/5xx</code> (idempotent methods by default).</p>
</li>
</ul>
</li>
<li>
<p><strong>Fixture entry point unchanged</strong>: <code inline="">ApiContexts.ts</code> still starts the journey via <code inline="">AdminApiContext.create(...)</code>.</p>
</li>
</ul>
<h2>Files</h2>
<ul>
<li>
<p><code inline="">services/TokenManager.ts</code> <strong>(new)</strong></p>
</li>
<li>
<p><code inline="">services/AdminApiContext.ts</code> <strong>(rewritten, same public surface)</strong></p>
</li>
<li>
<p><code inline="">tests/fixtures/ApiContexts.ts</code> <strong>(unchanged usage)</strong></p>
</li>
</ul>
<h2>How it works</h2>
<h3>Request flow</h3>
<ol>
<li>
<p><code inline="">TokenManager.getValidAccessToken()</code> refreshes <strong>proactively</strong> if expiry is near (≤ 60s).</p>
</li>
<li>
<p>Request is sent with <code inline="">Authorization: Bearer &lt;token&gt;</code>.</p>
</li>
<li>
<p>If response is <strong><code inline="">401</code></strong>:</p>
<ul>
<li>
<p><code inline="">TokenManager.forceRefresh()</code> (still singleflight).</p>
</li>
<li>
<p>Retry <strong>exactly once</strong>.</p>
</li>
</ul>
</li>
<li>
<p>If response is <strong><code inline="">429</code> or <code inline="">5xx</code></strong>:</p>
<ul>
<li>
<p>Bounded exponential backoff (200ms → 400ms → 800ms + jitter) for <strong>idempotent</strong> methods.</p>
</li>
</ul>
</li>
</ol>
<h3>Refresh vs re-auth</h3>
<ul>
<li>
<p>Try <strong>refresh</strong> first when a refresh token exists.</p>
</li>
<li>
<p>On token-endpoint <code inline="">invalid_grant</code>/<code inline="">400–401</code> → <strong>full re-auth</strong>:</p>
<ul>
<li>
<p>Use <strong>Client Credentials</strong> (<code inline="">client_id</code> + <code inline="">client_secret</code>) when no username/password.</p>
</li>
<li>
<p>Otherwise <strong>Password</strong> flow (<code inline="">admin_username</code> + <code inline="">admin_password</code>).</p>
</li>
</ul>
</li>
<li>
<p>Persist rotated <code inline="">refresh_token</code> when provided.</p>
</li>
<li>
<p>Compute <code inline="">expiresAt</code> from <code inline="">expires_in</code>; default to <strong>5 minutes</strong> if missing.</p>
</li>
</ul>
<h2>Before / After</h2>

Scenario | Before | After
-- | -- | --
Many requests 401 simultaneously | Multiple racing refreshes | One refresh; others await it
Refresh token invalid/expired | Often fails again | Full re-auth fallback
Token expires mid-flight | Flaky first call | Proactive refresh (60s skew)
429/5xx responses | None/inconsistent | Bounded backoff (idempotent only)
Rotated refresh token | Next refresh fails | Rotated token is stored


<h2>Public API / Migration</h2>
<ul>
<li>
<p><code inline="">AdminApiContext.create(baseUrl?, overrides?)</code> → <strong>unchanged</strong>.</p>
</li>
<li>
<p>Convenience methods (<code inline="">get/post/put/patch/delete</code>) → <strong>unchanged</strong>.</p>
</li>
<li>
<p>Optional overrides supported:</p>
<ul>
<li>
<p><code inline="">token_endpoint</code> (default <code inline="">/oauth/token</code>)</p>
</li>
<li>
<p><code inline="">max_retries</code> (idempotent methods; default <code inline="">2</code>)</p>
</li>
<li>
<p><code inline="">default_headers</code></p>
</li>
<li>
<p>Existing auth fields (<code inline="">client_id</code>, <code inline="">client_secret</code>, <code inline="">admin_username</code>, <code inline="">admin_password</code>, <code inline="">scope</code>, initial <code inline="">access_token</code>, <code inline="">refresh_token</code>, <code inline="">expires_in</code>).</p>
</li>
</ul>
</li>
</ul>
<h2>Examples</h2>
<pre><code class="language-ts">// Client Credentials
await AdminApiContext.create(process.env.APP_URL, {
  client_id: process.env.CLIENT_ID,
  client_secret: process.env.CLIENT_SECRET,
  scope: 'admin',
});
</code></pre>
<pre><code class="language-ts">// Password flow (supports refresh &amp; rotation)
await AdminApiContext.create(process.env.APP_URL, {
  client_id: process.env.CLIENT_ID,
  client_secret: process.env.CLIENT_SECRET,
  admin_username: process.env.ADMIN_USER,
  admin_password: process.env.ADMIN_PASS,
  scope: 'admin',
});
</code></pre>
<h2>Edge cases handled</h2>
<ul>
<li>
<p>Clock skew between CI and IdP (proactive refresh).</p>
</li>
<li>
<p>Refresh-token <strong>rotation</strong>.</p>
</li>
<li>
<p>Revoked/invalid refresh tokens (<code inline="">invalid_grant</code> → re-auth).</p>
</li>
<li>
<p>Concurrent <code inline="">401</code>s (singleflight refresh).</p>
</li>
<li>
<p>Missing <code inline="">expires_in</code> (fallback TTL 5 min).</p>
</li>
<li>
<p>Scope/audience differences via re-auth flow selection.</p>
</li>
</ul>
<h2>Tests to validate</h2>
<ul>
<li>
<p><strong>Revoked refresh</strong> → token endpoint <code inline="">400 invalid_grant</code> → full re-auth → request succeeds.</p>
</li>
<li>
<p><strong>Rotation</strong> → refresh returns new <code inline="">refresh_token</code> → subsequent refresh uses it.</p>
</li>
<li>
<p><strong>Clock skew</strong> → short <code inline="">expires_in</code> (e.g., 5s) → proactive refresh occurs.</p>
</li>
<li>
<p><strong>Concurrency</strong> → expire token, fire 10 parallel calls → <strong>one</strong> refresh request total.</p>
</li>
<li>
<p><strong>Backoff</strong> → simulate <code inline="">429</code> twice then <code inline="">200</code> → idempotent-only retries.</p>
</li>
<li>
<p><strong>Wrong scope</strong> → resource <code inline="">403</code> → surfaced clearly (not hidden by auth retries).</p>
</li>
</ul>
<h2>Risks &amp; mitigations</h2>
<ul>
<li>
<p>Centralized token path touches all requests → strict <strong>single</strong> retry on <code inline="">401</code>, no loops.</p>
</li>
<li>
<p>More frequent re-auth when refresh is invalid → gated by <code inline="">invalid_grant</code>/<code inline="">400–401</code> only.</p>
</li>
<li>
<p>Backoff adds small latency on transient failures → bounded and idempotent-only by default.</p>
</li>
</ul>
<h2>Developer notes</h2>
<ul>
<li>
<p>Per-request headers are preserved and merged; <code inline="">Authorization</code> is appended last.</p>
</li>
<li>
<p>Token endpoint uses its own <code inline="">request.newContext</code> (keeps concerns isolated).</p>
</li>
<li>
<p>Skew/backoff are small and can be tuned (<code inline="">skewMs</code>, <code inline="">max_retries</code>) if staging shows different behavior.</p>
</li>
</ul>
<hr>
