### PR TITLE
fix: use oidc auth for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,12 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.release_created }}
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
+        if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
+      # authentication happens automatically via OIDC. See https://www.npmjs.com/package/@shopware-ag/acceptance-test-suite/access for more details.
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers

This will allow us to separate the auth from specific users and use short lived tokens via oidc trust relationships