### PR TITLE
fix: update locale-mappings and correct translationKeys

### DIFF
--- a/src/locales/de/storefront/checkout.json
+++ b/src/locales/de/storefront/checkout.json
@@ -5,53 +5,31 @@
         "paidInAdvance": "Vorkasse",
         "invoice": "Rechnung",
         "standard": "Standard",
-        "express": "Express"
+        "express": "Express",
+        "grandTotal": "Gesamtsumme",
+        "plusVat": "zzgl.",
+        "vatSuffix": " % MwSt."
     },
     "cart": {
-        "addToCart": "In den Warenkorb",
-        "removeFromCart": "Aus dem Warenkorb entfernen",
-        "quantity": "Anzahl",
-        "price": "Preis",
-        "subtotal": "Zwischensumme",
-        "total": "Gesamt",
-        "emptyCart": "Ihr Warenkorb ist leer",
-        "continueShopping": "Weiter einkaufen",
-        "proceedToCheckout": "Zur Kasse",
         "shoppingCart": "Warenkorb",
         "goToCheckout": "Zur Kasse gehen",
         "displayShoppingCart": "Warenkorb anzeigen",
+        "continueShopping": "Weiter einkaufen",
         "promoCode": "Aktionscode",
+        "emptyCart": "Ihr Warenkorb ist leer.",
+        "quantity": "Anzahl",
         "stockReached": "nur noch 1x verfügbar"
     },
     "confirm": {
-        "confirmOrder": "Bestellung bestätigen",
-        "orderSummary": "Bestellübersicht",
-        "shippingAddress": "Lieferadresse",
-        "billingAddress": "Rechnungsadresse",
-        "shippingMethod": "Versandart",
-        "paymentMethod": "Zahlungsart",
-        "agreeToTerms": "Ich stimme den AGBs zu",
-        "revocationNotice": "Widerrufsbelehrung",
         "completeOrder": "Bestellung abschließen",
         "submitOrder": "Zahlungspflichtig bestellen",
         "termsAndConditions": "Ich habe die AGB gelesen und bin mit ihnen einverstanden.",
         "immediateAccessToDigitalProduct": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt."
     },
     "finish": {
-        "thankYou": "Vielen Dank für Ihre Bestellung",
-        "thankYouForOrder": "Vielen Dank für Ihre Bestellung",
-        "orderNumber": "Bestellnummer",
-        "orderConfirmation": "Bestellbestätigung",
-        "continueShopping": "Weiter einkaufen",
-        "grandTotal": "Gesamtsumme",
-        "plusVat": "zzgl.",
-        "vatSuffix": "% MwSt."
+        "thankYouForOrder": "Vielen Dank für Ihre Bestellung"
     },
     "orderEdit": {
         "cancelOrder": "Bestellung stornieren"
-    },
-    "register": {
-        "createAccount": "Konto erstellen",
-        "guestCheckout": "Als Gast bestellen"
     }
 }

--- a/src/locales/en/storefront/checkout.json
+++ b/src/locales/en/storefront/checkout.json
@@ -5,7 +5,10 @@
         "paidInAdvance": "Paid in advance",
         "invoice": "Invoice",
         "standard": "Standard",
-        "express": "Express"
+        "express": "Express",
+        "grandTotal": "Grand total",
+        "plusVat": "plus",
+        "vatSuffix": "% VAT"
     },
     "cart": {
         "shoppingCart": "Shopping cart",
@@ -24,10 +27,7 @@
         "immediateAccessToDigitalProduct": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel."
     },
     "finish": {
-        "thankYouForOrder": "Thank you for your order",
-        "grandTotal": "Grand total",
-        "plusVat": "plus",
-        "vatSuffix": "% VAT"
+        "thankYouForOrder": "Thank you for your order"
     },
     "orderEdit": {
         "cancelOrder": "Cancel order"

--- a/src/page-objects/administration/DataSharing.ts
+++ b/src/page-objects/administration/DataSharing.ts
@@ -25,7 +25,7 @@ export class DataSharing implements PageObject {
 
         this.dataSharingAgreeButton = page.getByRole('button', { name: translate('administration:dataSharing:buttons.agree') });
         this.dataSharingDisableButton = page.getByRole('button', { name: translate('administration:dataSharing:buttons.disableDataSharing') });
-        this.dataSharingSuccessMessageLabel = page.getByText('You are sharing data with us', { exact: true });
+        this.dataSharingSuccessMessageLabel = page.getByText(translate('administration:dataSharing:messages.sharingData'), { exact: true });
         this.dataSharingTermsAgreementLabel = page.getByText(translate('administration:dataSharing:messages.termsAgreement'));
     }
 

--- a/src/page-objects/storefront/CheckoutCart.ts
+++ b/src/page-objects/storefront/CheckoutCart.ts
@@ -12,8 +12,8 @@ export class CheckoutCart implements PageObject {
     public readonly cartLineItemImages: Locator;
     public readonly unitPriceInfo: Locator;
     public readonly cartQuantityNumber: Locator;
-    public readonly productNameLabel:(productName: string) => Locator;
-    public readonly productNumberLabel:(productNumber: string) => Locator;
+    public readonly productNameLabel: (productName: string) => Locator;
+    public readonly productNumberLabel: (productNumber: string) => Locator;
     public readonly productDeliveryDateLabel: Locator;
 
     public readonly page: Page;
@@ -23,7 +23,7 @@ export class CheckoutCart implements PageObject {
         this.headline = page.getByRole('heading', { name: translate('storefront:checkout:cart.shoppingCart') });
         this.goToCheckoutButton = page.getByRole('link', { name: translate('storefront:checkout:cart.goToCheckout') });
         this.enterPromoInput = page.getByLabel(translate('storefront:checkout:cart.promoCode'));
-        this.grandTotalPrice = page.locator(`dt:has-text("${translate('storefront:checkout:finish.grandTotal')}") + dd:visible`);
+        this.grandTotalPrice = page.locator(`dt:has-text("${translate('storefront:checkout:common.grandTotal')}") + dd:visible`);
         this.emptyCartAlert = page.getByText(translate('storefront:checkout:cart.emptyCart'));
         this.stockReachedAlert = page.getByText(translate('storefront:checkout:cart.stockReached'));
         this.cartLineItemImages = page.locator('.line-item-img-link');

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -34,8 +34,8 @@ export class CheckoutConfirm implements PageObject {
         this.headline = page.getByRole('heading', { name: translate('storefront:checkout:confirm.completeOrder') });
         this.termsAndConditionsCheckbox = page.getByLabel(translate('storefront:checkout:confirm.termsAndConditions'));
         this.immediateAccessToDigitalProductCheckbox = page.getByLabel(translate('storefront:checkout:confirm.immediateAccessToDigitalProduct'));
-        this.grandTotalPrice = page.locator(`dt:has-text('Grand total') + dd`);
-        this.taxPrice = page.locator(`dt:text-matches('plus [0-9]\\+\\?% VAT') + dd`);
+        this.grandTotalPrice = page.locator(`dt:has-text('${translate('storefront:checkout:common.grandTotal')}') + dd`);
+        this.taxPrice = page.locator(`dt:text-matches("${translate('storefront:checkout:common.plusVat')} [0-9]\\+\\?${translate('storefront:checkout:common.vatSuffix')}") + dd`);
         this.submitOrderButton = page.getByRole('button', { name: translate('storefront:checkout:confirm.submitOrder') });
 
         this.paymentCashOnDelivery = page.getByLabel(translate('storefront:checkout:common.cashOnDelivery'));

--- a/src/page-objects/storefront/CheckoutFinish.ts
+++ b/src/page-objects/storefront/CheckoutFinish.ts
@@ -16,8 +16,8 @@ export class CheckoutFinish implements PageObject {
         this.page = page;
         this.headline = page.getByRole('heading', { name: translate('storefront:checkout:finish.thankYouForOrder') });
         this.orderNumberText = page.getByText(this.orderNumberRegex);
-        this.grandTotalPrice = page.locator(`dt:has-text("${translate('storefront:checkout:finish.grandTotal')}") + dd`);
-        this.taxPrice = page.locator(`dt:text-matches('${translate('storefront:checkout:finish.plusVat')} [0-9]\\+\\?${translate('storefront:checkout:finish.vatSuffix')}') + dd`);
+        this.grandTotalPrice = page.locator(`dt:has-text("${translate('storefront:checkout:common.grandTotal')}") + dd`);
+        this.taxPrice = page.locator(`dt:text-matches("${translate('storefront:checkout:common.plusVat')} [0-9]\\+\\?${translate('storefront:checkout:common.vatSuffix')}") + dd`);
         this.cartLineItemImages = page.locator('.line-item-img-link');
     }
 

--- a/src/services/ShopwareDataHelpers.ts
+++ b/src/services/ShopwareDataHelpers.ts
@@ -28,7 +28,7 @@ export const COUNTRY_ADDRESS_DATA = {
     US: {
         street: '1600 Pennsylvania Avenue NW',
         city: 'Washington',
-        country: 'United States',
+        country: 'United States of America',
         postalCode: '20500',
         vatRegNo: 'US123456789',
     },

--- a/src/services/ShopwareDataHelpers.ts
+++ b/src/services/ShopwareDataHelpers.ts
@@ -55,24 +55,39 @@ export const getLocale = (): string => {
     return LOCALE_MAPPINGS[locale] ? locale : 'en-GB';
 };
 
-export const getLanguageCode = (locale: string): string => {
-    const mapping = LOCALE_MAPPINGS[locale];
+export const getLanguageCode = (locale?: string): string => {
+    const mapping = LOCALE_MAPPINGS[locale ?? getLocale()];
     return mapping ? mapping.languageCode : 'en-GB';
 };
 
-export const getCountryCodeFromLocale = (locale: string): string => {
-    const mapping = LOCALE_MAPPINGS[locale];
+export const getCountryCodeFromLocale = (locale?: string): string => {
+    const mapping = LOCALE_MAPPINGS[locale ?? getLocale()];
     return mapping ? mapping.countryCode : 'GB';
 };
 
-export const getCurrencyCodeFromLocale = (locale: string): string => {
-    const mapping = LOCALE_MAPPINGS[locale];
+export const getCurrencyCodeFromLocale = (locale?: string): string => {
+    const mapping = LOCALE_MAPPINGS[locale ?? getLocale()];
     return mapping ? mapping.currencyCode : 'GBP';
 };
 
-export const getCurrencySymbolFromLocale = (locale: string): string => {
-    const mapping = LOCALE_MAPPINGS[locale];
+export const getCurrencySymbolFromLocale = (locale?: string): string => {
+    const mapping = LOCALE_MAPPINGS[locale ?? getLocale()];
     return mapping ? mapping.currencySymbol : '£';
+};
+
+export const formatPrice = (price: number, locale?: string, currencyCode?: string): string => {
+    const currentLocale = locale || getLocale();
+    const currency = currencyCode || getCurrencyCodeFromLocale(currentLocale);
+
+    const formatter = new Intl.NumberFormat(currentLocale, {
+        style: 'currency',
+        currency: currency,
+        currencyDisplay: 'symbol',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+
+    return formatter.format(price).replace(/\u00A0/g, ' ');
 };
 
 type Language = components['schemas']['Language'] & {


### PR DESCRIPTION
**Localization Key Consolidation and Cleanup**
* Moved duplicate checkout price and tax label translations (`grandTotal`, `plusVat`, `vatSuffix`) from multiple sections to a new `common` group in both English and German locale files, and removed redundant keys from `finish` and other sections. [[1]](diffhunk://#diff-c042837257f495bccf0beea6b1cf084ada02d3dbd76903c471cfe3418ce778a3L8-L55) [[2]](diffhunk://#diff-932c45a100daf114cede7540730e950ac16342f7c63e6c03ceaa2b73de93f1b3L8-R11) [[3]](diffhunk://#diff-932c45a100daf114cede7540730e950ac16342f7c63e6c03ceaa2b73de93f1b3L27-R30)
* Cleaned up unused and redundant translation keys in the German checkout locale file, streamlining the translation structure.

**Page Object Updates for Consistent Localization**
* Updated selectors in `CheckoutCart`, `CheckoutConfirm`, and `CheckoutFinish` page objects to use the new `common` translation keys for price and tax labels, ensuring consistency across checkout steps. [[1]](diffhunk://#diff-8387e49c7ba33c87b9d4c6353231e5ad6b87f3460369d097fa9f7e2a43a45b7eL26-R26) [[2]](diffhunk://#diff-4d69ad614cf814cac5da1e571c49dd014259ec37b12529b90ed6561587087aa4L37-R38) [[3]](diffhunk://#diff-45fc1ee9f0a5522e43ec164b71ad986031db1af258810363b68234f35ed0575aL19-R20)
* Refactored the success message selector in `DataSharing` page object to use a translation key instead of a hardcoded string, improving internationalization support.

**Locale Helper Function Improvements**
* Changed locale helper functions (`getLanguageCode`, `getCountryCodeFromLocale`, `getCurrencyCodeFromLocale`, `getCurrencySymbolFromLocale`) to accept an optional locale parameter and default to the current locale if not provided, improving API flexibility and preventing errors.
* Added a new `formatPrice` utility to format prices according to locale and currency, using `Intl.NumberFormat` for proper localization and symbol display.

**Minor Data Correction**
* Updated the country name for the US address data to "United States of America" for accuracy.