### PR TITLE
fix: review filter rating locator

### DIFF
--- a/src/page-objects/storefront/Home.ts
+++ b/src/page-objects/storefront/Home.ts
@@ -139,7 +139,7 @@ export class Home implements PageObject {
     }
 
     async getRatingItemLocatorByRating(rating: number): Promise<Locator> {
-        return this.productRatingList.getByLabel(`min. ${rating}/5`);
+        return this.productRatingList.getByText(`min. ${rating}/5`);
     }
 
     async getFilterItemByFilterName(filterName: string): Promise<Locator> {


### PR DESCRIPTION
`getByLabel` doesn't work with the latest changes.
https://github.com/shopware/shopware/pull/13493