### PR TITLE
feat: Optimize TestDataService cleanup operations

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -1903,17 +1903,20 @@ export class TestDataService {
                 deleteOperations[`delete-${record.resource}`].payload.push(record.payload);
             }
         });
+        
+        if (Object.keys(priorityDeleteOperations).length > 0) {
+            const priorityDeleteOperationsResponse = await this.AdminApiClient.post('_action/sync', {
+                data: priorityDeleteOperations,
+            });
+            expect(priorityDeleteOperationsResponse.ok()).toBeTruthy();
+        }
 
-        const priorityDeleteOperationsResponse = await this.AdminApiClient.post('_action/sync', {
-            data: priorityDeleteOperations,
-        });
-
-        expect(priorityDeleteOperationsResponse.ok()).toBeTruthy();
-
-        const restoreSystemConfigResponse = await this.AdminApiClient.post(`_action/system-config?_response=detail&salesChannelId=${this.defaultSalesChannel.id}`, {
-            data: this.restoreSystemConfig,
-        });
-        expect(restoreSystemConfigResponse.ok()).toBeTruthy();
+        if (Object.keys(this.restoreSystemConfig).length > 0) {
+            const restoreSystemConfigResponse = await this.AdminApiClient.post(`_action/system-config?_response=detail&salesChannelId=${this.defaultSalesChannel.id}`, {
+                data: this.restoreSystemConfig,
+            });
+            expect(restoreSystemConfigResponse.ok()).toBeTruthy();
+        }
 
         if (deleteUserIds.length > 0) {
             for (const userId of deleteUserIds) {


### PR DESCRIPTION
Cleanup from TestDataService fires a call to reset settings to default after each test, even if no settings were changed. Saves us potentially a lot of empty system-config calls.
Same with priority deletions of test data entities.