### PR TITLE
fix: presses and navigation stability

### DIFF
--- a/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
+++ b/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
@@ -7,7 +7,7 @@ export const ProceedFromCartToCheckout = base.extend<{ ProceedFromCartToCheckout
         ShopCustomer,
         StorefrontCheckoutCart,
         StorefrontCheckoutConfirm,
-        StorefrontPage
+        StorefrontPage,
     }, use) => {
         const task = () => {
             return async function ProceedFromCartToCheckout() {

--- a/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
+++ b/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
@@ -11,7 +11,7 @@ export const ProceedFromCartToCheckout = base.extend<{ ProceedFromCartToCheckout
         const task = () => {
             return async function ProceedFromCartToCheckout() {
                 await ShopCustomer.presses(StorefrontCheckoutCart.goToCheckoutButton);
-                await StorefrontCheckoutConfirm.page.waitForURL('commit');
+                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         }

--- a/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
+++ b/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
@@ -7,12 +7,11 @@ export const ProceedFromCartToCheckout = base.extend<{ ProceedFromCartToCheckout
         ShopCustomer,
         StorefrontCheckoutCart,
         StorefrontCheckoutConfirm,
-        StorefrontPage,
     }, use) => {
         const task = () => {
             return async function ProceedFromCartToCheckout() {
                 await ShopCustomer.presses(StorefrontCheckoutCart.goToCheckoutButton);
-                await StorefrontPage.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
+                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         }

--- a/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
+++ b/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
@@ -7,11 +7,12 @@ export const ProceedFromCartToCheckout = base.extend<{ ProceedFromCartToCheckout
         ShopCustomer,
         StorefrontCheckoutCart,
         StorefrontCheckoutConfirm,
+        StorefrontPage
     }, use) => {
         const task = () => {
             return async function ProceedFromCartToCheckout() {
                 await ShopCustomer.presses(StorefrontCheckoutCart.goToCheckoutButton);
-                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
+                await StorefrontPage.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         }

--- a/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
+++ b/src/tasks/shop-customer/Cart/ProceedFromCartToCheckout.ts.ts
@@ -10,7 +10,8 @@ export const ProceedFromCartToCheckout = base.extend<{ ProceedFromCartToCheckout
     }, use) => {
         const task = () => {
             return async function ProceedFromCartToCheckout() {
-                await StorefrontCheckoutCart.goToCheckoutButton.click();
+                await ShopCustomer.presses(StorefrontCheckoutCart.goToCheckoutButton);
+                await StorefrontCheckoutConfirm.page.waitForURL('commit');
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         }

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -3,11 +3,11 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
-    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish }, use)=> {
+    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage }, use)=> {
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
-                await StorefrontCheckoutFinish.page.waitForURL('**/checkout/finish',{ waitUntil: 'commit' });
+                await StorefrontPage.waitForURL('**/checkout/finish',{ waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -3,11 +3,11 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
-    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage }, use)=> {
+    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish }, use)=> {
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
-                await StorefrontPage.waitForURL('**/checkout/finish**', { waitUntil: 'commit' });
+                await StorefrontCheckoutFinish.page.waitForURL('**/checkout/finish**', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -6,7 +6,8 @@ export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
     SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish }, use)=> {
         const task = () => {
             return async function SubmitOrder() {
-                await StorefrontCheckoutConfirm.submitOrderButton.click();
+                await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
+                await StorefrontCheckoutFinish.page.waitForURL('commit');
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -7,7 +7,7 @@ export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
-                await StorefrontCheckoutFinish.page.waitForURL('commit');
+                await StorefrontCheckoutFinish.page.waitForURL('**/checkout/finish',{ waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -3,7 +3,7 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
-    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage, }, use)=> {
+    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage }, use)=> {
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -7,7 +7,7 @@ export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
-                await StorefrontPage.waitForURL('**/checkout/finish**',{ waitUntil: 'commit' });
+                await StorefrontPage.waitForURL('**/checkout/finish**', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Checkout/SubmitOrder.ts
+++ b/src/tasks/shop-customer/Checkout/SubmitOrder.ts
@@ -3,11 +3,11 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const SubmitOrder = base.extend<{ SubmitOrder: Task }, FixtureTypes>({
-    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage }, use)=> {
+    SubmitOrder: async ({ ShopCustomer, StorefrontCheckoutConfirm, StorefrontCheckoutFinish, StorefrontPage, }, use)=> {
         const task = () => {
             return async function SubmitOrder() {
                 await ShopCustomer.presses(StorefrontCheckoutConfirm.submitOrderButton);
-                await StorefrontPage.waitForURL('**/checkout/finish',{ waitUntil: 'commit' });
+                await StorefrontPage.waitForURL('**/checkout/finish**',{ waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
+++ b/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
@@ -3,12 +3,12 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const ProceedFromProductToCheckout = base.extend<{ ProceedFromProductToCheckout: Task }, FixtureTypes>({
-    ProceedFromProductToCheckout: async ({ ShopCustomer, StorefrontProductDetail, StorefrontCheckoutConfirm, StorefrontPage }, use)=> {
+    ProceedFromProductToCheckout: async ({ ShopCustomer, StorefrontProductDetail, StorefrontCheckoutConfirm }, use)=> {
         const task = () => {
             return async function ProceedFromProductToCheckout() {
                 await StorefrontProductDetail.offCanvasCartGoToCheckoutButton.scrollIntoViewIfNeeded();
                 await ShopCustomer.presses(StorefrontProductDetail.offCanvasCartGoToCheckoutButton);
-                await StorefrontPage.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
+                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
+++ b/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
@@ -8,7 +8,7 @@ export const ProceedFromProductToCheckout = base.extend<{ ProceedFromProductToCh
             return async function ProceedFromProductToCheckout() {
                 await StorefrontProductDetail.offCanvasCartGoToCheckoutButton.scrollIntoViewIfNeeded();
                 await ShopCustomer.presses(StorefrontProductDetail.offCanvasCartGoToCheckoutButton);
-                await StorefrontCheckoutConfirm.page.waitForURL('commit');
+                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
+++ b/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
@@ -3,12 +3,12 @@ import type { Task } from '../../../types/Task';
 import type { FixtureTypes} from '../../../types/FixtureTypes';
 
 export const ProceedFromProductToCheckout = base.extend<{ ProceedFromProductToCheckout: Task }, FixtureTypes>({
-    ProceedFromProductToCheckout: async ({ ShopCustomer, StorefrontProductDetail, StorefrontCheckoutConfirm }, use)=> {
+    ProceedFromProductToCheckout: async ({ ShopCustomer, StorefrontProductDetail, StorefrontCheckoutConfirm, StorefrontPage }, use)=> {
         const task = () => {
             return async function ProceedFromProductToCheckout() {
                 await StorefrontProductDetail.offCanvasCartGoToCheckoutButton.scrollIntoViewIfNeeded();
                 await ShopCustomer.presses(StorefrontProductDetail.offCanvasCartGoToCheckoutButton);
-                await StorefrontCheckoutConfirm.page.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
+                await StorefrontPage.waitForURL('**/checkout/confirm', { waitUntil: 'commit' });
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         };

--- a/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
+++ b/src/tasks/shop-customer/Product/ProceedFromProductToCheckout.ts
@@ -6,7 +6,9 @@ export const ProceedFromProductToCheckout = base.extend<{ ProceedFromProductToCh
     ProceedFromProductToCheckout: async ({ ShopCustomer, StorefrontProductDetail, StorefrontCheckoutConfirm }, use)=> {
         const task = () => {
             return async function ProceedFromProductToCheckout() {
-                await StorefrontProductDetail.offCanvasCartGoToCheckoutButton.click();
+                await StorefrontProductDetail.offCanvasCartGoToCheckoutButton.scrollIntoViewIfNeeded();
+                await ShopCustomer.presses(StorefrontProductDetail.offCanvasCartGoToCheckoutButton);
+                await StorefrontCheckoutConfirm.page.waitForURL('commit');
                 await ShopCustomer.expects(StorefrontCheckoutConfirm.headline).toBeVisible();
             }
         };


### PR DESCRIPTION
The `Go to Checkout ` link on the off-canvas was flaky because Playwright would try to focus the link sometimes before the canvas was finished loading/animating. 

Additionally, I noticed some potential for flakiness with `Submit Order` and `Go To Checkout`. Pressing (or clicking) these links create a redirect which Playwright has no knowledge of, so I added the automatic waits in as is [best practice](https://playwright.dev/docs/navigations).