### PR TITLE
fix: typo in default address in de locale

### DIFF
--- a/src/locales/de/storefront/account.json
+++ b/src/locales/de/storefront/account.json
@@ -97,7 +97,7 @@
     },
     "tasks": {
         "registration": {
-            "defaultStreet": "Ebbinghof 10",
+            "defaultStreet": "Ebbinghoff 10",
             "defaultCity": "Schöppingen",
             "defaultCountry": "Deutschland",
             "defaultDepartment": "Betrieb",


### PR DESCRIPTION
Default address in de locale was "Ebbinghof" instead of "Ebbinghoff"