### PR TITLE
fix: use StoreApiContext for isThemeCompiled

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -52,7 +52,7 @@ export const test = base.extend<FixtureTypes>({
         await AdminApiContext.delete(`user/${uuid}`);
     },
 
-    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, InstanceMeta, CustomTranslationResources }, use) => {
+    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, StoreApiContext, InstanceMeta, CustomTranslationResources }, use) => {
         const { url, salesChannel } = DefaultSalesChannel;
         const locale = getLocale();
         const languageHelper = await LanguageHelper.createInstance(locale, CustomTranslationResources);
@@ -69,7 +69,7 @@ export const test = base.extend<FixtureTypes>({
         setCurrentContext(context as unknown as Record<string, unknown>);
 
         let page;
-        if (!(await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url))) {
+        if (!(await isThemeCompiled(StoreApiContext, DefaultSalesChannel.url))) {
             base.slow();
 
             await AdminApiContext.post(`./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${salesChannel.id}`);
@@ -78,7 +78,7 @@ export const test = base.extend<FixtureTypes>({
             page = await context.newPage();
 
             if (InstanceMeta.isSaaS) {
-                while (!(await isThemeCompiled(AdminApiContext, DefaultSalesChannel.url))) {
+                while (!(await isThemeCompiled(StoreApiContext, DefaultSalesChannel.url))) {
                     await clearDelayedCache(AdminApiContext);
                     await page.waitForTimeout(4000);
                 }

--- a/src/services/ShopInfo.ts
+++ b/src/services/ShopInfo.ts
@@ -1,11 +1,12 @@
 import { type AdminApiContext } from './AdminApiContext';
+import { type StoreApiContext } from './StoreApiContext';
 
 export const isSaaSInstance = async (adminApiContext: AdminApiContext): Promise<boolean> => {
     const instanceFeatures = await adminApiContext.get('./instance/features');
     return instanceFeatures.ok();
 };
 
-export const isThemeCompiled = async (context: AdminApiContext, storefrontUrl: string): Promise<boolean> => {
+export const isThemeCompiled = async (context: StoreApiContext, storefrontUrl: string): Promise<boolean> => {
     const response = await context.get(storefrontUrl);
 
     const body = (await response.body()).toString();


### PR DESCRIPTION
We should use the StoreApiContext for checking the `all.css`. The AdminApiContext uses the Admin Bearer Token and as we now have a better error reporting on the saas CDN,  the isThemeCompiled check will fail on saas.