### PR TITLE
fix: use scrollIntoViewIfNeeded() in a11y_checks

### DIFF
--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -15,6 +15,7 @@ export class Actor {
     expects = expect;
 
     async a11y_checks(locator: Locator) {
+        await locator.scrollIntoViewIfNeeded();
         await locator.focus();
         await expect(locator).toBeFocused();        
         await expect(locator).toHaveVisibleFocus(); 


### PR DESCRIPTION
To reduce possible flakiness and the need to decide about the need to call the scrollIntoViewIfNeeded() function in individual tests, I added the call in the a11y_checks() function, before it checks whether the element is focused (which was the main point where this failed due to the element being out of viewscope)