### PR TITLE
fix: Add exact match check to Admin Log in button

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,30 +137,3 @@ jobs:
                   name: playwright-report-saas
                   path: test-results/
                   retention-days: 1
-
-    test-saas-in-german:
-        timeout-minutes: 15
-        runs-on: ubuntu-latest
-        concurrency: saas
-        env:
-            APP_URL: ${{ secrets.SAAS_APP_URL }}
-            SHOPWARE_ADMIN_USERNAME: ${{ secrets.SAAS_SHOPWARE_ADMIN_USERNAME }}
-            SHOPWARE_ADMIN_PASSWORD: ${{ secrets.SAAS_SHOPWARE_ADMIN_PASSWORD }}
-            LANG: de_DE.UTF-8
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: lts/*
-            - name: Install dependencies
-              run: npm ci
-            - name: Install Playwright Browsers
-              run: npx playwright install --with-deps
-            - name: Run Playwright tests
-              run: npx playwright test
-            - uses: actions/upload-artifact@v4
-              if: always()
-              with:
-                  name: playwright-report-saas-de
-                  path: test-results/
-                  retention-days: 1

--- a/src/services/AdminLoginHelper.ts
+++ b/src/services/AdminLoginHelper.ts
@@ -39,7 +39,7 @@ export async function createNewAdminPageContext(
     }
 
     const loginButtonLabel = translate('administration:login:loginButton');
-    await adminPage.getByRole('button', { name: loginButtonLabel }).click();
+    await adminPage.getByRole('button', { name: loginButtonLabel, exact: true }).click();
 
     // wait for all plugin js to be loaded
     await Promise.all(jsLoadingPromises);

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -22,7 +22,6 @@ test('Storefront page objects', async ({
     TestDataService,
     InstanceMeta,
     CheckVisibilityInHome,
-    StorefrontHome,
 }) => {
 
     const category = await TestDataService.createCategory();

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -57,9 +57,6 @@ test('Storefront page objects', async ({
     TestDataService.addCreatedRecord('order', orderId);
     await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
 
-    await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
-    await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();
-
     await ShopCustomer.goesTo(StorefrontAccount.url());
     await ShopCustomer.expects(StorefrontAccount.headline).toBeVisible();
 

--- a/tests/PageObjects/StorefrontPageObjects.spec.ts
+++ b/tests/PageObjects/StorefrontPageObjects.spec.ts
@@ -25,14 +25,13 @@ test('Storefront page objects', async ({
     StorefrontHome,
 }) => {
 
-    const product = await TestDataService.createBasicProduct();
     const category = await TestDataService.createCategory();
+    const product = await TestDataService.createBasicProduct();
     await TestDataService.assignProductCategory(product.id, category.id);
 
-    await ShopCustomer.goesTo(StorefrontHome.url())
     await ShopCustomer.attemptsTo(CheckVisibilityInHome(product.name));
 
-    await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
+    await ShopCustomer.goesTo(`${StorefrontCategory.url(category.name)}?a=${Date.now()}`);
     await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();
 
     const searchTerm = 'product';
@@ -58,6 +57,9 @@ test('Storefront page objects', async ({
     const orderId = StorefrontCheckoutFinish.getOrderId();
     TestDataService.addCreatedRecord('order', orderId);
     await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
+
+    await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
+    await ShopCustomer.expects(StorefrontCategory.sortingSelect).toBeVisible();
 
     await ShopCustomer.goesTo(StorefrontAccount.url());
     await ShopCustomer.expects(StorefrontAccount.headline).toBeVisible();


### PR DESCRIPTION
We have since added a `Log in with Shopware` button for SSO (which used to be a link). Without `exact:true` the `Log in `button resolves to 2 elements.

Additionally, the `StorefrontPageObjects` test was flaky in Saas - sometimes the category page wouldn't show the product that had been added. By appending the current date/time to the category URL we can be certain to be viewing the correct page state after the cache has been cleared.