### PR TITLE
chore(ci): adjust Playwright retries for CI environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
             - name: Run Playwright tests against Shopware ${{ matrix.SHOPWARE_VERSION }}
               env:
                   APP_URL: http://localhost:${{ matrix.PORT }}
-              run: npx playwright test --repeat-each 4
+              run: npx playwright test --repeat-each 2
 
             - name: Execute changed testcases repeatedly ${{ matrix.SHOPWARE_VERSION }}
               if: steps.changed-test-files.outputs.all_changed_files_count > 0
@@ -133,7 +133,7 @@ jobs:
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
             - name: Run Playwright tests
-              run: npx playwright test --repeat-each 2
+              run: npx playwright test
             - uses: actions/upload-artifact@v6
               if: always()
               with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,8 @@ export default defineConfig({
     expect: {
         timeout: 30_000,
     },
-    retries: 0,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
     workers: process.env.CI ? 2 : 1,
     reporter: process.env.CI ? [["html"], ["github"]] : "html",
     use: {


### PR DESCRIPTION
In that PR I want to introduce retries = 2 if a test in SaaS is failing for example. Furthermore, I want to speed up the saas run while I'm removing the `repeat-each` option for SaaS instance. Besides that reduce the `repeat-each` to 2 for platform runs.