### PR TITLE
feat: add enable check in accessability check

### DIFF
--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -16,6 +16,7 @@ export class Actor {
 
     async a11y_checks(locator: Locator) {
         await locator.scrollIntoViewIfNeeded();
+        await expect(locator).toBeEnabled();
         await locator.focus();
         await expect(locator).toBeFocused();
         await expect(locator).toHaveVisibleFocus();


### PR DESCRIPTION
Currently, we have the issue that in mostly cloud CI runs and mostly in dialogues the `expect(locator).toBeFocused();` accessibility check fails because the element/locator is inactive. 

Playwright do nativly some actionability checks before performing actions like click, scrollIntoView, but sometimes also not. ([ref](https://playwright.dev/docs/actionability)) 

In our code base with the accessibility check, we imitate the click event with keyboard actions. In conclusion, we have to take care if a locator/element has the state we actually need for testing (in theorie see reference above)

With that change, we make sure our element is:
- Stable -> [locator.scrollIntoViewIfNeeded()](https://playwright.dev/docs/api/class-locator#locator-scroll-into-view-if-needed)
- Enabled -> [expect(locator).toBeEnabled()](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-enabled)

With that minimal change, we wanna observe if more checks (visi
ble, receivesEvents) are in the future needed and if the issue is solved properly.

Trace of the issue see attached.
[trace.zip](https://github.com/user-attachments/files/25440699/trace.zip)
