### PR TITLE
fix: more timeout so make task more stable

### DIFF
--- a/src/tasks/shop-admin/ShopwareServices/CheckVisibilityOfServicesBanner.ts
+++ b/src/tasks/shop-admin/ShopwareServices/CheckVisibilityOfServicesBanner.ts
@@ -16,7 +16,7 @@ export const CheckVisibilityOfServicesBanner = base.extend<{ CheckVisibilityOfSe
                     TestDataService.AdminApiClient,
                 );
                 const shopwareServicesAdvertisementBanner = adminPage.locator(".sw-settings-services-dashboard-banner__content").first();
-                await expect(shopwareServicesAdvertisementBanner).toBeVisible();
+                await expect(shopwareServicesAdvertisementBanner).toBeVisible({ timeout: 10_000 });
             };
         };
         await use(task);


### PR DESCRIPTION
It maid happen the services banner is not loaded within 5 sec (mostly in cloud). Timeout increased, so that the test has more time to assert.