### PR TITLE
fix: add param to refresh opensearch when clearing the cache

### DIFF
--- a/src/services/Cache.ts
+++ b/src/services/Cache.ts
@@ -1,5 +1,5 @@
 import { type AdminApiContext } from "./AdminApiContext";
 
 export const clearDelayedCache = async (adminApiContext: AdminApiContext): Promise<void> => {
-    await adminApiContext.delete("./_action/cache-delayed");
+    await adminApiContext.delete("./_action/cache-delayed?refreshOpenSearch=true");
 };


### PR DESCRIPTION
See Core PR for analysis: https://github.com/shopware/shopware/pull/15162

The change should be backward compatible to old shops, as the query param is simply ignored if they are running on older versions