### PR TITLE
fix: proper re-export of playwright types

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -4,4 +4,20 @@ export default defineBuildConfig({
     entries: ["src/index"],
     declaration: true,
     externals: [/^(?:@playwright\/test|playwright|playwright-core)(?:\/.*)?$/, "@shopware/api-client", "@axe-core/playwright", "axe-html-reporter", "axe-core", "image-js", "uuid"],
+    hooks: {
+        "rollup:dts:options": (_ctx, options) => {
+            // The DTS bundler follows @playwright/test's re-export chain
+            // (export * from 'playwright/test') and emits the resolved
+            // specifier for namespace imports. Consumers don't have the
+            // unscoped `playwright` package, so rewrite it back.
+            const plugins = Array.isArray(options.plugins) ? options.plugins : options.plugins ? [options.plugins] : [];
+            plugins.push({
+                name: "rewrite-playwright-dts-imports",
+                renderChunk(code: string) {
+                    return code.replace(/from ['"]playwright\/test['"]/g, "from '@playwright/test'");
+                },
+            });
+            options.plugins = plugins;
+        },
+    },
 });


### PR DESCRIPTION
there is a problem with reaching proper playwright files when using ATS. It does not affect runtime, but only type definitions and IDE support.

This PR fixes the issue with playwright typing and brings back proper DX.