### PR TITLE
fix: broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 # Shopware Acceptance Test Suite
 
-This repository remains the source code for the test suite but all guides, examples, and setup instructions is in the [documentation](https://developer.shopware.com/docs/guides/plugins/plugins/testing/playwright/)
+This repository remains the source code for the test suite but all guides, examples, and setup instructions is in the [documentation](https://developer.shopware.com/docs/guides/development/testing/e2e-playwright/)
 
 Feel free to open [issues](https://github.com/shopware/acceptance-test-suite/issues) or [pull requests](https://github.com/shopware/acceptance-test-suite/pulls) for bugs or improvements related to the test suite code itself.


### PR DESCRIPTION
This PR fixes broken link, as reported in [Discord](https://discord.com/channels/1308047705309708348/1367208211635114035/1483103180823728291).