### PR TITLE
fix: use stable selector for storefront registration submit button

### DIFF
--- a/src/page-objects/storefront/AccountLogin.ts
+++ b/src/page-objects/storefront/AccountLogin.ts
@@ -90,7 +90,8 @@ export class AccountLogin implements PageObject {
         this.shippingAddressCountryInput = this.registerShippingAddressFormArea.getByLabel(translate("storefront:login:register.country"));
         this.shippingAddressPostalCodeInput = this.registerShippingAddressFormArea.getByLabel(translate("storefront:login:register.postalCode"));
         this.shippingAddressStateInput = this.registerShippingAddressFormArea.getByLabel(translate("storefront:login:register.state"));
-        this.registerButton = page.getByRole("button", { name: translate("storefront:login:register.continue") });
+        // The submit label differs between storefront account registration and checkout registration.
+        this.registerButton = page.locator("form.register-form button[type=\"submit\"]");
         this.logoutLink = page.getByRole("link", { name: translate("storefront:login:logout") });
         this.successAlert = page.getByText(translate("storefront:login:successfulLogout"));
         this.passwordUpdatedAlert = page.getByText(translate("storefront:login:passwordUpdated"));


### PR DESCRIPTION
### 1. Why is this change necessary?

The shared ATS `AccountLogin` page object currently locates the registration submit button by the translated `storefront:login:register.continue` label. After the related storefront change in shopware/shopware, account registration uses a different submit label than checkout registration, so consumers need a selector that does not depend on that translation.

### 2. What does this change do, exactly?

It updates the shared `StorefrontAccountLogin.registerButton` locator to target the registration form submit button directly instead of matching a specific translated label.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use the ATS `StorefrontAccountLogin` page object on storefront account registration.
2. Run against the related storefront branch where the account registration submit label differs from checkout registration.
3. Observe that tests using `registerButton` no longer find the button by the old translation-based selector.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/shopware/pull/15471

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the Documenting a Release Process guide for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
