### PR TITLE
fix: cart line item stock rule selector

### DIFF
--- a/src/page-objects/administration/RuleDetail.ts
+++ b/src/page-objects/administration/RuleDetail.ts
@@ -143,7 +143,7 @@ export class RuleDetail extends RuleCreate implements PageObject {
             this.assignmentModalAddButton = this.assignmentModal.locator(".sw-button--primary").getByText(translate("administration:rule:buttons.add"));
         } else {
             this.assignmentModalAddButton = this.assignmentModal.locator(".mt-button--primary").getByText(translate("administration:rule:buttons.add"));
-        }git
+        }
         this.conditionORContainer = page.locator(".sw-condition-or-container");
     }
 

--- a/src/page-objects/administration/RuleDetail.ts
+++ b/src/page-objects/administration/RuleDetail.ts
@@ -137,8 +137,13 @@ export class RuleDetail extends RuleCreate implements PageObject {
         }
         this.conditionFilterModal = page.locator(".sw-modal__header").getByText(translate("administration:rule:text.filter"));
         this.conditionFilterModalCloseButtonX = page.locator(".sw-modal__header").getByRole("button");
-        this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemActualStock").locator(".sw-single-select__selection-text");
-        this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemActualStock").getByRole("textbox");
+        if (satisfies(instanceMeta.version, "<6.7.9.0")) {
+            this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemStock").locator(".sw-single-select__selection-text");
+            this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemStock").getByRole("textbox");
+        } else {
+            this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemActualStock").locator(".sw-single-select__selection-text");
+            this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemActualStock").getByRole("textbox");
+        }
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.assignmentModalAddButton = this.assignmentModal.locator(".sw-button--primary").getByText(translate("administration:rule:buttons.add"));
         } else {

--- a/src/page-objects/administration/RuleDetail.ts
+++ b/src/page-objects/administration/RuleDetail.ts
@@ -137,13 +137,13 @@ export class RuleDetail extends RuleCreate implements PageObject {
         }
         this.conditionFilterModal = page.locator(".sw-modal__header").getByText(translate("administration:rule:text.filter"));
         this.conditionFilterModalCloseButtonX = page.locator(".sw-modal__header").getByRole("button");
-        this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemStock").locator(".sw-single-select__selection-text");
-        this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemStock").getByRole("textbox");
+        this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemActualStock").locator(".sw-single-select__selection-text");
+        this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemActualStock").getByRole("textbox");
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.assignmentModalAddButton = this.assignmentModal.locator(".sw-button--primary").getByText(translate("administration:rule:buttons.add"));
         } else {
             this.assignmentModalAddButton = this.assignmentModal.locator(".mt-button--primary").getByText(translate("administration:rule:buttons.add"));
-        }
+        }git
         this.conditionORContainer = page.locator(".sw-condition-or-container");
     }
 


### PR DESCRIPTION
Because of deprecation of `ProductEntity.availableStock` and removing the rule `cartLineItemStock` we need to adjust the selector to `cartLineItemActualStock`

see PR: https://github.com/shopware/shopware/pull/16015
