### PR TITLE
feat: add createSolidColorImage and createMediaPNGSolid for visual tests

### DIFF
--- a/src/services/ImageHelper.ts
+++ b/src/services/ImageHelper.ts
@@ -17,6 +17,24 @@ export function createRandomImage(width = 800, height = 600) {
     });
 }
 
+export function createSolidColorImage(width = 800, height = 600, color: [number, number, number] = [255, 0, 0]) {
+    const channels = 3; // RGB
+    const data = new Uint8Array(width * height * channels);
+    const [r, g, b] = color;
+
+    for (let i = 0; i < data.length; i += channels) {
+        data[i] = r;
+        data[i + 1] = g;
+        data[i + 2] = b;
+    }
+
+    return new Image(width, height, {
+        colorModel: "RGB",
+        bitDepth: 8,
+        data,
+    });
+}
+
 export function encodeImage(image: Image) {
     return Buffer.from(encode(image));
 }

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -1,4 +1,4 @@
-import { createRandomImage, encodeImage } from "./ImageHelper";
+import { createRandomImage, createSolidColorImage, encodeImage } from "./ImageHelper";
 import { getCountryAddressData, getLanguageData, getPromotionWithDiscount, getSnippetSetId, updateAdminUser } from "./ShopwareDataHelpers";
 import type { AdminApiContext } from "./AdminApiContext";
 import type { IdProvider } from "./IdProvider";
@@ -406,6 +406,30 @@ export class TestDataService {
      */
     async createMediaPNG(width = 800, height = 600): Promise<Media> {
         const image = createRandomImage(width, height);
+        const media = await this.createMediaResource();
+        const filename = `${this.namePrefix}Media-${media.id}${this.nameSuffix}`;
+
+        const response = await this.AdminApiClient.post(`_action/media/${media.id}/upload?extension=png&fileName=${filename}`, {
+            data: encodeImage(image),
+            headers: { "content-type": "image/png" },
+        });
+        expect(response.ok()).toBeTruthy();
+
+        this.addCreatedRecord("media", media.id);
+
+        return media;
+    }
+
+    /**
+     * Creates a new media resource containing a solid color PNG image.
+     * Unlike `createMediaPNG`, the result is deterministic and suitable for visual regression tests.
+     *
+     * @param width - The width of the image in pixel. Default is 800.
+     * @param height - The height of the image in pixel. Default is 600.
+     * @param color - RGB color as `[r, g, b]` with values 0..255. Default is red `[255, 0, 0]`.
+     */
+    async createMediaPNGSolid(width = 800, height = 600, color: [number, number, number] = [255, 0, 0]): Promise<Media> {
+        const image = createSolidColorImage(width, height, color);
         const media = await this.createMediaResource();
         const filename = `${this.namePrefix}Media-${media.id}${this.nameSuffix}`;
 

--- a/tests/TestDataService/TestDataService.spec.ts
+++ b/tests/TestDataService/TestDataService.spec.ts
@@ -69,6 +69,9 @@ test("Data Service", async ({ TestDataService, AdminApiContext }) => {
     const manufacturerWithImage = await TestDataService.createManufacturerWithImage();
     expect(manufacturerWithImage.media).toBeDefined();
 
+    const solidColorMedia = await TestDataService.createMediaPNGSolid(100, 100, [255, 0, 0]);
+    expect(solidColorMedia.id).toBeDefined();
+
     await TestDataService.assignManufacturerProduct(manufacturer.id, product.id);
     expect(product.manufacturerId).toBeDefined();
 


### PR DESCRIPTION
## What?

Adds `createSolidColorImage()` to `ImageHelper` and `TestDataService.createMediaPNGSolid()` to create deterministic solid color PNG images.

## Why?

The existing `createRandomImage` / `createMediaPNG` use `Math.random()` without a seed, producing different pixels on every run. This is unsuitable for visual regression tests where the same image must be reproduced consistently.

## How?

- New `createSolidColorImage(width, height, color)` in `ImageHelper.ts` — fills an RGB buffer with a fixed color.
- New `TestDataService.createMediaPNGSolid(width, height, color)` — wraps the above and uploads the image via the media API, mirroring the existing `createMediaPNG` pattern.
- Added a coverage check in the existing `Data Service` test.

Non-breaking: existing `createRandomImage` and `createMediaPNG` are untouched.

## Usage

```ts
const media = await TestDataService.createMediaPNGSolid(1200, 800, [255, 0, 0]);
```

### Example
<img width="1280" height="1577" alt="image" src="https://github.com/user-attachments/assets/18571b62-03df-403a-bc50-918899c6b435" />

