### PR TITLE
fix: update flow name for getFlowId

### DIFF
--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -39,7 +39,6 @@ test("Administration page objects - Settings.", async ({
 
     const flowId = await getFlowId("Order enters status cancelled", AdminApiContext);
     await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId)); 
-
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 
     // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -37,8 +37,14 @@ test("Administration page objects - Settings.", async ({
         await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
     }
 
-    const flowId = await getFlowId("Payment enters status unconfirmed", AdminApiContext);
-    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
+    if (satisfies(InstanceMeta.version, ">=6.7.9")) {
+        const flowId = await getFlowId("Payment enters status unconfirmed", AdminApiContext);
+        await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId)); 
+    } 
+    else {
+        const flowId = await getFlowId("Order enters status unconfirmed", AdminApiContext);
+        await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
+    }
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 
     // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -37,14 +37,9 @@ test("Administration page objects - Settings.", async ({
         await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
     }
 
-    if (satisfies(InstanceMeta.version, ">=6.7.9")) {
-        const flowId = await getFlowId("Payment enters status unconfirmed", AdminApiContext);
-        await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId)); 
-    } 
-    else {
-        const flowId = await getFlowId("Order enters status unconfirmed", AdminApiContext);
-        await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
-    }
+    const flowId = await getFlowId("Order enters status cancelled", AdminApiContext);
+    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId)); 
+
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 
     // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -37,7 +37,7 @@ test("Administration page objects - Settings.", async ({
         await ShopAdmin.expects(AdminFlowBuilderListing.createFlowButton).toBeVisible();
     }
 
-    const flowId = await getFlowId("Order enters status unconfirmed", AdminApiContext);
+    const flowId = await getFlowId("Payment enters status unconfirmed", AdminApiContext);
     await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 

--- a/tests/PageObjects/AdministrationSettings.spec.ts
+++ b/tests/PageObjects/AdministrationSettings.spec.ts
@@ -38,7 +38,7 @@ test("Administration page objects - Settings.", async ({
     }
 
     const flowId = await getFlowId("Order enters status cancelled", AdminApiContext);
-    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId)); 
+    await ShopAdmin.goesTo(AdminFlowBuilderDetail.url(flowId));
     await ShopAdmin.expects(AdminFlowBuilderDetail.saveButton).toBeVisible();
 
     // todo: fix unsaved changes issue on the previous page so that we don't have to do a hard reload


### PR DESCRIPTION
SaaS pipelines was [failing](https://github.com/shopware/acceptance-test-suite/actions/runs/24346259303/job/71093209818?pr=619) due to mismatch of flow names which have been updated in https://github.com/shopware/shopware/pull/15611.

For simplicity and ease of backwards compatibility, a different flow was chosen.