### PR TITLE
chore: require reviews from test-engineers team on every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Review required for every PR
+*   @shopware/test-engineers


### PR DESCRIPTION
Should automatically add @shopware/test-engineers as reviewers to every PR. Existing repo rules should enforce that at least 1 approval is needed from @shopware/test-engineers in order to merge.