### PR TITLE
fix: dismisses the storefront cookie banner when it appears

### DIFF
--- a/tests/CustomMatchers.spec.ts
+++ b/tests/CustomMatchers.spec.ts
@@ -3,6 +3,12 @@ import { test } from "../src";
 test("Check for visible focus", async ({ ShopCustomer, StorefrontHome, StorefrontHeader }) => {
     await ShopCustomer.goesTo(StorefrontHome.url());
 
+    if (await StorefrontHome.consentOnlyTechnicallyRequiredButton.isVisible()) {
+        await ShopCustomer.presses(StorefrontHome.consentOnlyTechnicallyRequiredButton);
+        await ShopCustomer.expects(StorefrontHome.consentCookieBannerContainer).not.toBeVisible();
+        await ShopCustomer.goesTo(StorefrontHome.url(), true);
+    }
+
     await test.step("Detect outline", async () => {
         await StorefrontHome.page.keyboard.press("Tab");
         await ShopCustomer.expects(StorefrontHeader.skipToMainContentLink).toBeVisible();


### PR DESCRIPTION
For this case, keeping it inline in tests/CustomMatchers.spec.ts is the better fit:
- It’s only used by one spec right now.
- It’s a short setup step, not the behavior the test is trying to prove.