### PR TITLE
fix: version switch regression

### DIFF
--- a/src/page-objects/administration/RuleDetail.ts
+++ b/src/page-objects/administration/RuleDetail.ts
@@ -137,7 +137,7 @@ export class RuleDetail extends RuleCreate implements PageObject {
         }
         this.conditionFilterModal = page.locator(".sw-modal__header").getByText(translate("administration:rule:text.filter"));
         this.conditionFilterModalCloseButtonX = page.locator(".sw-modal__header").getByRole("button");
-        if (satisfies(instanceMeta.version, "<6.7.9.0")) {
+        if (satisfies(instanceMeta.version, "<6.7.10.0")) {
             this.conditionCartLineItemInStockOperator = page.locator(".sw-condition__condition-type-cartLineItemStock").locator(".sw-single-select__selection-text");
             this.conditionCartLineItemInStockValue = page.locator(".sw-condition__condition-type-cartLineItemStock").getByRole("textbox");
         } else {


### PR DESCRIPTION
The fix was intended for version 6.7.9. However, it wasn't merged until version 6.7.10.

See: https://github.com/shopware/shopware/pull/16015