### PR TITLE
feat: expose PaaS instance metadata

### DIFF
--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -78,7 +78,7 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
                 }
             }
 
-            use({
+            await use({
                 version: config.version,
                 isSaaS: await isSaaSInstance(context),
                 isPaaS: isPaaSInstance(),

--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -1,6 +1,6 @@
 import { test as base, expect } from "@playwright/test";
 import { IdProvider } from "../services/IdProvider";
-import { isSaaSInstance } from "../services/ShopInfo";
+import { isPaaSInstance, isSaaSInstance } from "../services/ShopInfo";
 import type { FixtureTypes } from "../types/FixtureTypes";
 import { getCurrency, getLanguageCode, getLanguageData, getLocale } from "../services/ShopwareDataHelpers";
 import { AdminApiContext } from "../services/AdminApiContext";
@@ -16,6 +16,7 @@ export interface HelperFixtureTypes {
     InstanceMeta: {
         version: string;
         isSaaS: boolean;
+        isPaaS: boolean;
         features: FeaturesType;
     };
     CustomTranslationResources: typeof BUNDLED_RESOURCES | undefined;
@@ -80,6 +81,7 @@ export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
             use({
                 version: config.version,
                 isSaaS: await isSaaSInstance(context),
+                isPaaS: isPaaSInstance(),
                 features,
             });
         },

--- a/src/services/ShopInfo.ts
+++ b/src/services/ShopInfo.ts
@@ -6,6 +6,10 @@ export const isSaaSInstance = async (adminApiContext: AdminApiContext): Promise<
     return instanceStatus.ok();
 };
 
+export const isPaaSInstance = (): boolean => {
+    return process.env.SHOPWARE_ACCEPTANCE_INSTANCE_TYPE === "paas";
+};
+
 export const isThemeCompiled = async (context: StoreApiContext, storefrontUrl: string): Promise<boolean> => {
     const response = await context.get(storefrontUrl);
 


### PR DESCRIPTION
## Summary

- Add `isPaaSInstance()` using `SHOPWARE_ACCEPTANCE_INSTANCE_TYPE=paas`.
- Expose `InstanceMeta.isPaaS` through the shared helper fixture.
- Keep existing SaaS detection based on `/api/instance/status` unchanged.

## Context

Nightly PaaS ATS runs can set `SHOPWARE_ACCEPTANCE_INSTANCE_TYPE=paas` so tests can skip or adapt behavior for PaaS without overloading `InstanceMeta.isSaaS`.

## Testing

- `git diff --check` passed locally on the patch.
- Typecheck was not run locally because dependencies were not installed in the scratch checkout.