### PR TITLE
chore: update i18next to 26.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@shopware/api-client": "1.4.0",
                 "axe-html-reporter": "2.2.11",
                 "compare-versions": "6.1.1",
-                "i18next": "25.8.3",
+                "i18next": "26.3.1",
                 "image-js": "1.3.0",
                 "uuid": "14.0.0"
             },
@@ -66,14 +66,6 @@
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
             "optional": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2877,29 +2869,26 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.3",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.3.tgz",
-            "integrity": "sha512-IC/pp2vkczdu1sBheq1eC92bLavN6fM5jH61c7Xa23PGio5ePEd+EP+re1IkO7KEM9eyeJHUxvIRxsaYTlsSyQ==",
+            "version": "26.3.1",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+            "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
+                    "url": "https://www.locize.com/i18next"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
                 }
             ],
             "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.4"
-            },
             "peerDependencies": {
-                "typescript": "^5"
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "typescript": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@shopware/api-client": "1.4.0",
         "axe-html-reporter": "2.2.11",
         "compare-versions": "6.1.1",
-        "i18next": "25.8.3",
+        "i18next": "26.3.1",
         "image-js": "1.3.0",
         "uuid": "14.0.0"
     },


### PR DESCRIPTION
## Summary
- update `i18next` from `25.8.3` to `26.3.1`
- remove the transitive `@babel/runtime` lockfile entry that is no longer required by i18next
- use the v26 release line, where the Locize support notice is no longer present in the published runtime

## Verification
- `git diff --check`
- JSON/lock consistency check with bundled Node
- inspected the published `i18next@26.3.1` CJS/ESM builds and confirmed the support-notice strings/code path are absent

Note: this intentionally takes the latest v26 patch instead of the smaller v25.10.10 update.