### PR TITLE
fix(acceptance):  PricingAndDiscountsForBundles strict-mode locator

### DIFF
--- a/src/page-objects/storefront/CheckoutCart.ts
+++ b/src/page-objects/storefront/CheckoutCart.ts
@@ -22,7 +22,7 @@ export class CheckoutCart implements PageObject {
         this.page = page;
         this.headline = page.getByRole("heading", { name: translate("storefront:checkout:cart.shoppingCart") });
         this.goToCheckoutButton = page.getByRole("link", { name: translate("storefront:checkout:cart.goToCheckout") });
-        this.enterPromoInput = page.getByLabel(translate("storefront:checkout:cart.promoCode"));
+        this.enterPromoInput = page.getByRole("textbox", { name: translate("storefront:checkout:cart.promoCode") });
         this.grandTotalPrice = page.locator(`dt:has-text("${translate("storefront:checkout:common.grandTotal")}") + dd:visible`);
         this.emptyCartAlert = page.getByText(translate("storefront:checkout:cart.emptyCart"));
         this.stockReachedAlert = page.getByText(translate("storefront:checkout:cart.stockReached"));


### PR DESCRIPTION
### 1. Why is this change necessary?

The `enterPromoInput` locator in the `CheckoutCart` page object used `getByLabel(...)` for the promo-code field. On the cart page that accessible label matches **2 elements**, so any interaction with `enterPromoInput` (used by `PricingAndDiscountsForBundles.spec.ts:210`) fails with a Playwright **strict-mode violation**.

### 2. What does this change do, exactly?

Resolves the promo-code field by its ARIA role instead of its label, so it matches exactly the one input element:

```diff
- this.enterPromoInput = page.getByLabel(translate("storefront:checkout:cart.promoCode"));
+ this.enterPromoInput = page.getByRole("textbox", { name: translate("storefront:checkout:cart.promoCode") });
```

`getByRole("textbox", { name })` keeps the same accessible-name match (still translation-driven, so it stays i18n-proof) while restricting the result to the actual text input, eliminating the ambiguous second match.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `PricingAndDiscountsForBundles.spec.ts` (the step at line 210 fills the promo-code input via `enterPromoInput`).
2. Before the fix: `getByLabel(...)` resolves to 2 elements and the action fails with a strict-mode violation.
3. After the fix: the locator resolves to the single promo-code textbox and the step proceeds.

### 4. Please link to the relevant issues (if any).

relates shopware/shopware#17455

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them