### PR TITLE
fix(bulk-edit): wait for save spinner before asserting customer bulk-edit success

### DIFF
--- a/src/page-objects/administration/CustomerBulkEdit.ts
+++ b/src/page-objects/administration/CustomerBulkEdit.ts
@@ -32,6 +32,7 @@ export class CustomerBulkEdit implements PageObject {
      */
     public readonly confirmModal: Locator;
     public readonly confirmModalApplyChangesButton: Locator;
+    public readonly confirmModalLoadingSpinner: Locator;
     public readonly confirmModalSuccessHeader: Locator;
     public readonly confirmModalSuccessCloseButton: Locator;
     public readonly page: Page;
@@ -75,6 +76,7 @@ export class CustomerBulkEdit implements PageObject {
         //Confirmation modal
         this.confirmModal = page.locator(".sw-bulk-edit-save-modal");
         this.confirmModalApplyChangesButton = this.confirmModal.getByRole("button", { name: translate("administration:customer:bulkEdit.applyChanges") });
+        this.confirmModalLoadingSpinner = this.confirmModal.locator(".sw-bulk-edit-save-modal__loading-icon");
         this.confirmModalSuccessHeader = this.confirmModal.getByRole("heading", { name: translate("administration:customer:bulkEdit.success") });
         const footer = this.confirmModal.locator(".sw-modal__footer");
         this.confirmModalSuccessCloseButton = footer.getByRole("button", { name: translate("administration:customer:bulkEdit.close") });

--- a/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
+++ b/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
@@ -67,6 +67,8 @@ export const BulkEditCustomers = base.extend<{ BulkEditCustomers: Task }, Fixtur
                 }
                 await AdminCustomerBulkEdit.applyChangesButton.click();
                 await AdminCustomerBulkEdit.confirmModalApplyChangesButton.click();
+                await AdminCustomerBulkEdit.confirmModalLoadingSpinner.waitFor({ state: "visible" });
+                await AdminCustomerBulkEdit.confirmModalLoadingSpinner.waitFor({ state: "hidden" });
                 await ShopAdmin.expects(AdminCustomerBulkEdit.confirmModalSuccessHeader).toBeVisible();
                 await AdminCustomerBulkEdit.confirmModalSuccessCloseButton.click();
             };


### PR DESCRIPTION
## Summary

`BulkEditCustomers` asserted the "Bulk edit - Success" heading immediately after confirming the save, with the default 5s `expect` timeout and no wait for the save to complete. The customer bulk-edit save (customer group, account status, language, tags, custom fields, across N customers) can take longer than 5s, so the success heading isn't visible yet and `toBeVisible()` fails with `element(s) not found` — a flake on loaded environments.

This mirrors the existing `BulkEditProducts` task, which already waits for the save-modal spinner before asserting success:

- add a `confirmModalLoadingSpinner` locator (`.sw-bulk-edit-save-modal__loading-icon`) to the `CustomerBulkEdit` page object
- in `BulkEditCustomers`, wait for that spinner `visible → hidden` before asserting `confirmModalSuccessHeader`

No new timeouts or magic numbers — it waits on the actual save signal, consistent with the product task.

## Verification

- `npm run build` succeeds
- synced the built `dist/index*` into a platform checkout and ran the consuming spec `BulkEdit/BulkEditCustomerInformation.spec.ts` with `--repeat-each=10` against a prod-mode shop — the previously intermittent success-modal failure no longer occurs

## Context

Companion to the platform-side flaky-test fix for shopware/shopware#17453. The platform PR hardens the verification-step value read-backs; this PR removes the success-modal race inside the shared bulk-edit task.