### PR TITLE
feat: add the create newsletter recipient request

### DIFF
--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -36,10 +36,11 @@ export class CheckoutConfirm implements PageObject {
     /**
      * Product details
      */
+    public readonly cartLineItemImages: Locator;
+    public readonly page: Page;
     public readonly confirmProductTable: Locator;
     public readonly productLineItems: Locator;
     public readonly promotionLineItems: Locator;
-    public readonly page: Page;
 
     constructor(page: Page) {
         this.page = page;

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -39,8 +39,6 @@ export class CheckoutConfirm implements PageObject {
     public readonly cartLineItemImages: Locator;
     public readonly page: Page;
     public readonly confirmProductTable: Locator;
-    public readonly productLineItems: Locator;
-    public readonly promotionLineItems: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -69,12 +67,10 @@ export class CheckoutConfirm implements PageObject {
         this.legalGuaranteeNoticeLink = page.locator("#legalGuaranteeNoticeModal a");
         this.lineItemGaranLabel = page.locator(".line-item-garan-label");
         this.confirmProductTable = page.locator(".confirm-product");
-        this.productLineItems = this.confirmProductTable.locator(".line-item-product");
-        this.promotionLineItems = this.confirmProductTable.locator(".line-item-promotion");
     }
 
-    getLineItemByProductName(lineItem: Locator, productName: string): Record<string, Locator> {
-        const productLineItem = lineItem.filter({ hasText: productName });
+    getLineItemByProductName(productName: string): Record<string, Locator> {
+        const productLineItem = this.confirmProductTable.locator(".line-item-product", { hasText: productName });
         const productNameLabel = productLineItem.locator(".line-item-label");
         const productTotalPrice = productLineItem.locator(".line-item-total-price-value");
 
@@ -82,6 +78,18 @@ export class CheckoutConfirm implements PageObject {
             productLineItem: productLineItem,
             productNameLabel: productNameLabel,
             productTotalPrice: productTotalPrice,
+        };
+    }
+
+    getLineItemByPromotionName(promotionName: string): Record<string, Locator> {
+        const promotionLineItem = this.confirmProductTable.locator(".line-item-promotion", { hasText: promotionName });
+        const promotionNameLabel = promotionLineItem.locator(".line-item-label");
+        const promotionTotalPrice = promotionLineItem.locator(".line-item-total-price-value");
+
+        return {
+            promotionLineItem: promotionLineItem,
+            promotionNameLabel: promotionNameLabel,
+            promotionTotalPrice: promotionTotalPrice,
         };
     }
 

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -36,7 +36,9 @@ export class CheckoutConfirm implements PageObject {
     /**
      * Product details
      */
-    public readonly cartLineItemImages: Locator;
+    public readonly confirmProductTable: Locator;
+    public readonly productLineItems: Locator;
+    public readonly promotionLineItems: Locator;
     public readonly page: Page;
 
     constructor(page: Page) {
@@ -65,6 +67,21 @@ export class CheckoutConfirm implements PageObject {
         this.termsAndConditionsWithLegalGuaranteeRightsLabel = page.getByLabel(translate("storefront:checkout:confirm.termsAndConditionsWithLegalGuaranteeRights"));
         this.legalGuaranteeNoticeLink = page.locator("#legalGuaranteeNoticeModal a");
         this.lineItemGaranLabel = page.locator(".line-item-garan-label");
+        this.confirmProductTable = page.locator(".confirm-product");
+        this.productLineItems = this.confirmProductTable.locator(".line-item-product");
+        this.promotionLineItems = this.confirmProductTable.locator(".line-item-promotion");
+    }
+
+    getLineItemByProductName(lineItem: Locator, productName: string): Record<string, Locator> {
+        const productLineItem = lineItem.filter({ hasText: productName });
+        const productNameLabel = productLineItem.locator(".line-item-label");
+        const productTotalPrice = productLineItem.locator(".line-item-total-price-value");
+
+        return {
+            productLineItem: productLineItem,
+            productNameLabel: productNameLabel,
+            productTotalPrice: productTotalPrice,
+        };
     }
 
     url() {

--- a/src/page-objects/storefront/OffCanvasCart.ts
+++ b/src/page-objects/storefront/OffCanvasCart.ts
@@ -68,4 +68,15 @@ export class OffCanvasCart implements PageObject {
             lineItemGaranLabel: lineItemGaranLabel,
         };
     }
+
+    async getLineItemByPromotionName(name: string): Promise<Record<string, Locator>> {
+        let promotionItem = this.page.locator(".line-item-promotion", { hasText: name });
+        const promotionLabel = promotionItem.locator(".line-item-label");
+        const promotionPrice = promotionItem.locator(".line-item-total-price-value");
+
+        return {
+            promotionLabel: promotionLabel,
+            promotionPrice: promotionPrice,
+        };
+    }
 }

--- a/src/page-objects/storefront/OffCanvasCart.ts
+++ b/src/page-objects/storefront/OffCanvasCart.ts
@@ -70,7 +70,7 @@ export class OffCanvasCart implements PageObject {
     }
 
     async getLineItemByPromotionName(name: string): Promise<Record<string, Locator>> {
-        let promotionItem = this.page.locator(".line-item-promotion", { hasText: name });
+        const promotionItem = this.page.locator(".line-item-promotion", { hasText: name });
         const promotionLabel = promotionItem.locator(".line-item-label");
         const promotionPrice = promotionItem.locator(".line-item-total-price-value");
 

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -18,6 +18,7 @@ import type {
     Language,
     Manufacturer,
     Media,
+    NewsletterRecipient,
     Order,
     OrderDelivery,
     OrderLineItem,
@@ -162,6 +163,35 @@ export class TestDataService {
         if (options.nameSuffix) {
             this.nameSuffix = options.nameSuffix;
         }
+    }
+
+    async createNewsletterRecipient(customer: Customer): Promise<NewsletterRecipient> {
+        const hash = this.IdProvider.getIdPair();
+
+        const recipientPayload = {
+            email: customer.email,
+            salesChannelId: this.defaultSalesChannel.id,
+            firstName: customer.firstName ?? "Test",
+            lastName: customer.lastName ?? "User",
+            hash: customer.id || hash,
+            status: "direct",
+            languageId: customer.languageId,
+            salutationId: customer.salutationId,
+            confirmedAt: new Date().toISOString(),
+        };
+
+        const resp = await this.AdminApiClient.post("newsletter-recipient?_response=detail", {
+            data: recipientPayload,
+        });
+
+        expect(resp.ok()).toBeTruthy();
+        const recipient = await resp.json();
+        if (recipient?.data?.id) {
+            this.addCreatedRecord("newsletter_recipient", recipient.data.id);
+        } else {
+            this.addCreatedRecord("newsletter_recipient", recipientPayload.email);
+        }
+        return recipient;
     }
 
     /**

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -187,14 +187,9 @@ export class TestDataService {
      * If a matching recipient already exists, it will be reused and registered for cleanup.
      *
      * @param customer - The customer whose email and profile data will be used for the newsletter recipient.
+     * @param overrides - Specific data overrides that will be applied to the newsletter recipient payload.
      */
-    async createNewsletterRecipient(customer: Customer): Promise<NewsletterRecipient> {
-        const existingNewsletterRecipient = await this.getNewsletterRecipient(customer);
-        if (existingNewsletterRecipient) {
-            this.addCreatedRecord("newsletter_recipient", existingNewsletterRecipient.id);
-            return existingNewsletterRecipient;
-        }
-
+    async createNewsletterRecipient(customer: Customer, overrides: Partial<NewsletterRecipient> = {}): Promise<NewsletterRecipient> {
         const hash = this.IdProvider.getIdPair();
         const recipientPayload = {
             email: customer.email,
@@ -206,7 +201,14 @@ export class TestDataService {
             languageId: customer.languageId,
             salutationId: customer.salutationId,
             confirmedAt: new Date().toISOString(),
+            ...overrides,
         };
+
+        const existingNewsletterRecipient = await this.getNewsletterRecipient({ ...customer, email: recipientPayload.email });
+        if (existingNewsletterRecipient) {
+            this.addCreatedRecord("newsletter_recipient", existingNewsletterRecipient.id);
+            return existingNewsletterRecipient;
+        }
 
         const resp = await this.AdminApiClient.post("newsletter-recipient?_response=detail", {
             data: recipientPayload,

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -165,9 +165,20 @@ export class TestDataService {
         }
     }
 
+    /**
+     * Creates a newsletter recipient for a customer in the default sales channel.
+     * If a matching recipient already exists, it will be reused and registered for cleanup.
+     *
+     * @param customer - The customer whose email and profile data will be used for the newsletter recipient.
+     */
     async createNewsletterRecipient(customer: Customer): Promise<NewsletterRecipient> {
-        const hash = this.IdProvider.getIdPair();
+        const existingNewsletterRecipient = await this.getNewsletterRecipient(customer);
+        if (existingNewsletterRecipient) {
+            this.addCreatedRecord("newsletter_recipient", existingNewsletterRecipient.id);
+            return existingNewsletterRecipient;
+        }
 
+        const hash = this.IdProvider.getIdPair();
         const recipientPayload = {
             email: customer.email,
             salesChannelId: this.defaultSalesChannel.id,
@@ -185,12 +196,8 @@ export class TestDataService {
         });
 
         expect(resp.ok()).toBeTruthy();
-        const recipient = await resp.json();
-        if (recipient?.data?.id) {
-            this.addCreatedRecord("newsletter_recipient", recipient.data.id);
-        } else {
-            this.addCreatedRecord("newsletter_recipient", recipientPayload.email);
-        }
+        const { data: recipient } = (await resp.json()) as { data: NewsletterRecipient };
+        this.addCreatedRecord("newsletter_recipient", recipient.id);
         return recipient;
     }
 
@@ -1578,6 +1585,35 @@ export class TestDataService {
         const { data: aclUser } = await syncAclUserResponse.json();
 
         return aclUser;
+    }
+
+    /**
+     * Retrieves a newsletter recipient by customer email and the default sales channel.
+     * @param customer - The customer whose email will be used to search for a newsletter recipient.
+     */
+    async getNewsletterRecipient(customer: Customer): Promise<NewsletterRecipient | undefined> {
+        const response = await this.AdminApiClient.post("search/newsletter-recipient", {
+            data: {
+                limit: 1,
+                filter: [
+                    {
+                        type: "equals",
+                        field: "email",
+                        value: customer.email,
+                    },
+                    {
+                        type: "equals",
+                        field: "salesChannelId",
+                        value: this.defaultSalesChannel.id,
+                    },
+                ],
+            },
+        });
+        expect(response.ok()).toBeTruthy();
+
+        const { data: result } = (await response.json()) as { data: NewsletterRecipient[] };
+
+        return result[0];
     }
 
     /**

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -886,7 +886,7 @@ export class TestDataService {
             personaRules: [
                 {
                     id: promotionConfig.ruleId,
-                } as Partial<Rule>,
+                } as Pick<Rule, "id">,
             ],
         });
 

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -883,19 +883,23 @@ export class TestDataService {
                     considerAdvancedRules: false,
                 },
             ],
-            personaRules: [
-                {
-                    id: promotionConfig.ruleId,
-                } as Pick<Rule, "id">,
-            ],
         });
 
         if (!useCode) {
             delete basicPromotion.code;
         }
 
+        const promotionWithConditionRule = {
+            ...basicPromotion,
+            personaRules: [
+                {
+                    id: promotionConfig.ruleId,
+                },
+            ],
+        };
+
         const promotionResponse = await this.AdminApiClient.post("promotion?_response=detail", {
-            data: basicPromotion,
+            data: promotionWithConditionRule,
         });
         expect(promotionResponse.ok()).toBeTruthy();
 

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -886,7 +886,7 @@ export class TestDataService {
             personaRules: [
                 {
                     id: promotionConfig.ruleId,
-                },
+                } as Partial<Rule>,
             ],
         });
 

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -71,6 +71,12 @@ export interface PromotionWithConditionRuleOptions {
     salesChannelId?: string;
 }
 
+export interface BasicRuleCondition {
+    type: string;
+    value: Record<string, unknown>;
+    children?: BasicRuleCondition[];
+}
+
 export interface SyncApiOperation {
     entity: string;
     action: "upsert" | "delete";
@@ -983,12 +989,14 @@ export class TestDataService {
     }
 
     /**
-     * Creates a new basic rule with the condition cart amount >= 1.
+     * Creates a new basic rule with the condition cart amount >= 1 by default.
+     * Pass a condition object to create the same basic rule structure with another condition.
      *
      * @param overrides - Specific data overrides that will be applied to the basic rule data struct.
+     * @param condition - The condition object or condition type used in the generated rule.
      */
-    async createBasicRule(overrides: Partial<Rule> = {}, conditionType = "cartCartAmount", operator = ">=", amount = 1): Promise<Rule> {
-        const basicRule = this.getBasicRuleStruct(overrides, conditionType, operator, amount);
+    async createBasicRule(overrides: Partial<Rule> = {}, condition: BasicRuleCondition | string = "cartCartAmount", operator = ">=", amount = 1): Promise<Rule> {
+        const basicRule = this.getBasicRuleStruct(overrides, condition, operator, amount);
 
         const ruleResponse = await this.AdminApiClient.post("rule?_response=detail", {
             data: basicRule,
@@ -2394,9 +2402,19 @@ export class TestDataService {
         return Object.assign({}, basicProduct, overrides);
     }
 
-    getBasicRuleStruct(overrides: Partial<Rule> = {}, conditionType: string, operator: string, amount: number): Partial<Rule> {
+    getBasicRuleStruct(overrides: Partial<Rule> = {}, condition: BasicRuleCondition | string = "cartCartAmount", operator = ">=", amount = 1): Partial<Rule> {
         const { id: ruleId, uuid: ruleUuid } = this.IdProvider.getIdPair();
         const ruleName = `${this.namePrefix}Rule-${ruleId}${this.nameSuffix}`;
+        const ruleCondition =
+            typeof condition === "string"
+                ? {
+                      type: condition,
+                      value: {
+                          operator: operator,
+                          amount: amount,
+                      },
+                  }
+                : condition;
 
         const description = `
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. 
@@ -2415,15 +2433,7 @@ export class TestDataService {
                     children: [
                         {
                             type: "andContainer",
-                            children: [
-                                {
-                                    type: conditionType,
-                                    value: {
-                                        operator: operator,
-                                        amount: amount,
-                                    },
-                                },
-                            ],
+                            children: [ruleCondition],
                         },
                     ],
                 },

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -60,6 +60,17 @@ export interface SimpleLineItem {
     overrides?: Partial<OrderLineItem>;
 }
 
+export interface PromotionWithConditionRuleOptions {
+    id: string;
+    name: string;
+    ruleId: string;
+    useCode?: boolean;
+    discountValue?: number;
+    discountScope?: string;
+    discountType?: string;
+    salesChannelId?: string;
+}
+
 export interface SyncApiOperation {
     entity: string;
     action: "upsert" | "delete";
@@ -849,6 +860,51 @@ export class TestDataService {
         this.addCreatedRecord("promotion", promotion.id);
 
         return promotionWithDiscount;
+    }
+
+    /**
+     * Creates a promotion with one discount and assigns a condition rule as a persona rule.
+     * The created promotion and assigned rule are both registered for cleanup.
+     *
+     * @param promotionConfig - Promotion configuration, including the promotion id, name, and assigned rule id.
+     */
+    async createPromotionWithConditionRule(promotionConfig: PromotionWithConditionRuleOptions): Promise<Promotion> {
+        const useCode = promotionConfig.useCode ?? false;
+        const basicPromotion = this.getBasicPromotionStruct(promotionConfig.salesChannelId, {
+            id: promotionConfig.id,
+            name: promotionConfig.name,
+            useCodes: useCode,
+            useIndividualCodes: useCode,
+            discounts: [
+                {
+                    scope: promotionConfig.discountScope ?? "cart",
+                    type: promotionConfig.discountType ?? "percentage",
+                    value: promotionConfig.discountValue ?? 10,
+                    considerAdvancedRules: false,
+                },
+            ],
+            personaRules: [
+                {
+                    id: promotionConfig.ruleId,
+                },
+            ],
+        });
+
+        if (!useCode) {
+            delete basicPromotion.code;
+        }
+
+        const promotionResponse = await this.AdminApiClient.post("promotion?_response=detail", {
+            data: basicPromotion,
+        });
+        expect(promotionResponse.ok()).toBeTruthy();
+
+        const { data: promotion } = (await promotionResponse.json()) as { data: Promotion };
+
+        this.addCreatedRecord("promotion", promotionConfig.id);
+        this.addCreatedRecord("rule", promotionConfig.ruleId);
+
+        return promotion;
     }
 
     /**

--- a/src/types/ShopwareTypes.ts
+++ b/src/types/ShopwareTypes.ts
@@ -1,5 +1,13 @@
 import type { components } from "@shopware/api-client/admin-api-types";
 
+export type NewsletterRecipient = components["schemas"]["NewsletterRecipient"] & {
+    id: string;
+    email: string;
+    salesChannelId: string;
+    firstName: string;
+    lastName: string;
+};
+
 export type SalesChannel = components["schemas"]["SalesChannel"] & {
     id: string;
 };


### PR DESCRIPTION
**Summary** 
- adding the support func for create newsletter recipient in the TestDataService 
- adding the product line items locator for checkout confirm and off canvas cart page

**Test Scenario Detail**
1. Admin creates promotion with rule Newsletter recipient = Yes (will automatically receive discount - 10% at checkout)
2. Shop user:
- registers the newsletter recipient 
- adds product to cart 
- validate promotion applied on checkout + confirm page and creating order

Related to test `CheckoutWithPromotionRule.spec.ts` in PR [17408](https://github.com/shopware/shopware/pull/17408)  