### PR TITLE
fix: declare @playwright/test as peerDependency to avoid duplicate playwright-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@axe-core/playwright": "4.11.1",
-                "@playwright/test": "1.60.0",
                 "@shopware/api-client": "1.4.0",
                 "axe-html-reporter": "2.2.11",
                 "compare-versions": "6.1.1",
@@ -19,6 +18,7 @@
                 "uuid": "14.0.0"
             },
             "devDependencies": {
+                "@playwright/test": "1.60.0",
                 "@types/node": "25.2.0",
                 "@types/uuid": "11.0.0",
                 "@typescript/native-preview": "7.0.0-dev.20260205.1",
@@ -27,10 +27,20 @@
                 "oxfmt": "0.28.0",
                 "oxlint": "1.43.0",
                 "oxlint-tsgolint": "0.11.4",
+                "playwright-core": "1.60.0",
                 "unbuild": "3.6.1"
             },
             "engines": {
                 "node": "24.x || 25.x"
+            },
+            "peerDependencies": {
+                "@playwright/test": "1.60.0",
+                "playwright-core": "1.60.0"
+            },
+            "peerDependenciesMeta": {
+                "playwright-core": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@axe-core/playwright": {
@@ -1045,6 +1055,7 @@
             "version": "1.60.0",
             "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
             "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright": "1.60.0"
@@ -2785,6 +2796,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -3874,6 +3886,7 @@
             "version": "1.60.0",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
             "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright-core": "1.60.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     },
     "dependencies": {
         "@axe-core/playwright": "4.11.1",
-        "@playwright/test": "1.60.0",
         "@shopware/api-client": "1.4.0",
         "axe-html-reporter": "2.2.11",
         "compare-versions": "6.1.1",
@@ -49,6 +48,7 @@
         "uuid": "14.0.0"
     },
     "devDependencies": {
+        "@playwright/test": "1.60.0",
         "@types/node": "25.2.0",
         "@types/uuid": "11.0.0",
         "@typescript/native-preview": "7.0.0-dev.20260205.1",
@@ -57,7 +57,17 @@
         "oxfmt": "0.28.0",
         "oxlint": "1.43.0",
         "oxlint-tsgolint": "0.11.4",
+        "playwright-core": "1.60.0",
         "unbuild": "3.6.1"
+    },
+    "peerDependencies": {
+        "@playwright/test": "1.60.0",
+        "playwright-core": "1.60.0"
+    },
+    "peerDependenciesMeta": {
+        "playwright-core": {
+            "optional": true
+        }
     },
     "engines": {
         "node": "24.x || 25.x"


### PR DESCRIPTION
## Problem

The suite re-exports Playwright's **runtime** (`test`, `expect`, `mergeTests`) and **types** (`Page`, `Locator`, `APIRequestContext`, … from `playwright-core`), but ships `@playwright/test` as a **hard `dependency`**.

Any consumer who also installs `@playwright/test` (which you must, to author a `playwright.config.ts` and run tests) can then end up with **two `playwright-core` copies**, which are distinct TypeScript identities. Real errors a consumer hits:

```
Argument of type 'Page' is not assignable to parameter of type 'Page'.
  (.../node_modules/playwright-core/... vs .../node_modules/playwright/node_modules/playwright-core/...)

Property 'toBeVisible' does not exist on type 'MakeMatchers<void, Locator, {}>'.
```

There are actually two contributing factors:

1. **`@playwright/test` is a dependency, not a peer.** A library that re-exports another library's public API/types should declare it as a peer so the consumer's single install is the only one.
2. **`@axe-core/playwright` peer-depends on `playwright-core` with a floating range** (`">= 1.0.0"`). Because the suite's own `playwright-core@1.60.0` lives nested under `playwright/node_modules/`, npm satisfies axe-core's *top-level* peer by installing the **latest** `playwright-core` (e.g. `1.61.0`) at the root — a second copy, even in a clean install.

### Reproduction

```bash
mkdir t && cd t && npm init -y
npm i -D @playwright/test@1.60.0 @shopware-ag/acceptance-test-suite
find node_modules -name playwright-core -maxdepth 3 -type d
# => node_modules/playwright-core (1.61.0)
#    node_modules/playwright/node_modules/playwright-core (1.60.0)
```

Then a page object that imports `Page` from `@playwright/test` and is passed to a suite fixture (`AdminPage`) fails to type-check, and `expect(locator).toBeVisible()` reports the matcher missing.

## Fix

- Move `@playwright/test` to `peerDependencies` (pinned `1.60.0`).
- Add `playwright-core` as an **optional** `peerDependency` pinned to the same version — this neutralises the floating `@axe-core/playwright` peer and guarantees a single `playwright-core` in the consumer tree.
- Keep both in `devDependencies` so the suite still builds and tests locally.

Playwright is already externalised in `build.config.ts`, so nothing is bundled — this only changes how the dependency is resolved in the consumer's tree.

## Verification

- `npm run build` (unbuild) still succeeds; all exports unchanged.
- In the suite's own tree the change collapses resolution to a **single `playwright-core@1.60.0`** (previously two).
- In a consumer project, `@playwright/test` + this suite now resolve to one `playwright-core`, and the `Page` / `toBeVisible` type errors disappear with no consumer-side `overrides` workaround.

## Notes

- This is technically a breaking change for any consumer that relied on the suite to transitively provide `@playwright/test` without installing it themselves. In practice every consumer needs `@playwright/test` to run Playwright at all, so impact should be minimal — but it may warrant a minor/major version bump and a changelog note ("add `@playwright/test` to your devDependencies").
