### PR TITLE
fix(bulk-edit): select customer bulk-edit tags via filtered search with retry

### DIFF
--- a/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
+++ b/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
@@ -52,12 +52,12 @@ export const BulkEditCustomers = base.extend<{ BulkEditCustomers: Task }, Fixtur
                     await AdminCustomerBulkEdit.changeTypeSelect.click();
                     await AdminCustomerBulkEdit.page.getByText(tagData.changeType).click();
                     for (const tag of tagData.tags) {
-                        // Retry: the API-created tag may lag in the search results (ES indexing).
+                        // Retry for ES-indexing lag; explicit timeout since toPass is unbounded by default.
                         await ShopAdmin.expects(async () => {
                             await AdminCustomerBulkEdit.enterTagsSelect.click();
                             await AdminCustomerBulkEdit.enterTagsSelect.fill(tag);
                             await AdminCustomerBulkEdit.filtersResultPopoverItemList.getByText(tag).click({ timeout: 5_000 });
-                        }).toPass({ intervals: [1_000, 2_000, 5_000] });
+                        }).toPass({ intervals: [1_000, 2_000, 5_000], timeout: 20_000 });
                     }
                 }
                 if (customFieldData) {

--- a/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
+++ b/src/tasks/shop-admin/Customers/BulkEditCustomers.ts
@@ -52,8 +52,12 @@ export const BulkEditCustomers = base.extend<{ BulkEditCustomers: Task }, Fixtur
                     await AdminCustomerBulkEdit.changeTypeSelect.click();
                     await AdminCustomerBulkEdit.page.getByText(tagData.changeType).click();
                     for (const tag of tagData.tags) {
-                        await AdminCustomerBulkEdit.enterTagsSelect.click();
-                        await AdminCustomerBulkEdit.page.getByText(tag).click();
+                        // Retry: the API-created tag may lag in the search results (ES indexing).
+                        await ShopAdmin.expects(async () => {
+                            await AdminCustomerBulkEdit.enterTagsSelect.click();
+                            await AdminCustomerBulkEdit.enterTagsSelect.fill(tag);
+                            await AdminCustomerBulkEdit.filtersResultPopoverItemList.getByText(tag).click({ timeout: 5_000 });
+                        }).toPass({ intervals: [1_000, 2_000, 5_000] });
                     }
                 }
                 if (customFieldData) {


### PR DESCRIPTION
## Summary

`BulkEditCustomers` selected each tag by clicking its text in the tag multi-select **without typing a search term** — it only focused the field, then clicked the option:

```js
await AdminCustomerBulkEdit.enterTagsSelect.click();
await AdminCustomerBulkEdit.page.getByText(tag).click();
```

The dropdown loads only the first **25 tags** (`{"term":"","limit":25}`, unsorted), so on any environment with more than 25 tags the freshly-created tag isn't on that first page and the click waits until the test times out (`Target page, context or browser has been closed`). It passed only on near-empty databases, which is why it flaked intermittently on unrelated PRs (relates to shopware/shopware#17453). On instances with an **Elasticsearch-backed** admin search (SaaS), there's a second cause: the API-created tag may not be indexed yet, so even a filtered search can momentarily return without it.

This change mirrors the already-correct `BulkEditProducts` task by **typing the tag name to filter the search**, and wraps the search-and-select in a `toPass` retry so an ES indexing lag costs a retry instead of a failure:

```js
for (const tag of tagData.tags) {
    // Retry: the API-created tag may lag in the search results (ES indexing).
    await ShopAdmin.expects(async () => {
        await AdminCustomerBulkEdit.enterTagsSelect.click();
        await AdminCustomerBulkEdit.enterTagsSelect.fill(tag);
        await AdminCustomerBulkEdit.filtersResultPopoverItemList.getByText(tag).click({ timeout: 5_000 });
    }).toPass({ intervals: [1_000, 2_000, 5_000] });
}
```

The retry is an intentional divergence from `BulkEditProducts` (which has none): the customer task creates its tags via API immediately before selecting them, so it's exposed to ES eventual-consistency in a way the product flow isn't.

## Verification

- `npm run build` succeeds.
- Synced the built `dist/index*` into a consumer checkout and ran `BulkEdit/BulkEditCustomerInformation.spec.ts` with `--repeat-each` against the SaaS nightly instance (44 tags + ES-backed search — the exact conditions that reproduced the failure). The previously intermittent tag-selection failure no longer occurs.

## Context

- Relates to shopware/shopware#17453 (flaky bulk-edit acceptance tests).
- Follow-up to the customer bulk-edit success-modal spinner fix (already merged) — different, earlier step in the same task.