### PR TITLE
test: update tests/PageObjects/AdministrationCustomerGroup.spec.ts to avoid pagination issues

### DIFF
--- a/src/page-objects/administration/CustomerGroupListing.ts
+++ b/src/page-objects/administration/CustomerGroupListing.ts
@@ -28,7 +28,14 @@ export class CustomerGroupListing implements PageObject {
         };
     }
 
-    url() {
-        return "#/sw/settings/customer/group/index";
+    url(searchTerms: string[] = [], page = 1) {
+        let url = "#/sw/settings/customer/group/index";
+
+        if (searchTerms.length > 0) {
+            const term = searchTerms.join("+");
+            url += `?limit=25&page=${page}&term=${encodeURIComponent(term)}`;
+        }
+
+        return url;
     }
 }

--- a/tests/PageObjects/AdministrationCustomerGroup.spec.ts
+++ b/tests/PageObjects/AdministrationCustomerGroup.spec.ts
@@ -3,7 +3,7 @@ import { test } from "../../src";
 test("Administration page objects - CustomerGroup.", async ({ ShopAdmin, AdminCustomerGroupListing, AdminCustomerGroupCreate, AdminCustomerGroupDetail, TestDataService }) => {
     const customerGroup = await TestDataService.createCustomerGroup();
 
-    await ShopAdmin.goesTo(AdminCustomerGroupListing.url());
+    await ShopAdmin.goesTo(AdminCustomerGroupListing.url([customerGroup.name]));
     await ShopAdmin.expects(AdminCustomerGroupListing.headline).toBeVisible();
     await ShopAdmin.expects(AdminCustomerGroupListing.addCustomerGroupButton).toBeVisible();
     const customerGroupRow = await AdminCustomerGroupListing.getCustomerGroupByName(customerGroup.name);


### PR DESCRIPTION
Fixes: https://github.com/shopware/acceptance-test-suite/issues/518

Now the test accounts for the fact the Customer Group created by the TestDataService may not appear on the first page of the listing, and directly searches/filters the listing page for it.