### PR TITLE
fix: set type: 'digital' in createDigitalProduct

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -243,7 +243,7 @@ export class TestDataService {
      * @param currencyId - The uuid of the currency to use for the product pricing.
      */
     async createDigitalProduct(content = "Lorem ipsum dolor", overrides: Partial<Product> = {}, taxId = this.defaultTaxId, currencyId = this.defaultCurrencyId): Promise<Product> {
-        const product = await this.createBasicProduct(overrides, taxId, currencyId);
+        const product = await this.createBasicProduct({ type: 'digital', ...overrides }, taxId, currencyId);
         const media = await this.createMediaTXT(content);
 
         await this.assignProductDownload(product.id, media.id);

--- a/src/types/ShopwareTypes.ts
+++ b/src/types/ShopwareTypes.ts
@@ -93,6 +93,7 @@ export type Product = Omit<components["schemas"]["Product"], "price" | "prices" 
     tags?: Record<string, string>[];
     visibilities?: Record<string, unknown>[];
     variantListingConfig?: VariantListingConfig;
+    type?: string;
 };
 
 export type ProductReview = components["schemas"]["ProductReview"] & {


### PR DESCRIPTION
Closes #654

## Problem

`TestDataService.createDigitalProduct()` created products without explicitly setting `type: 'digital'`. Tests relying on this helper were exercising an invalid product state that does not represent real production data — the same class of invalid test data that let the digital product download incident go undetected while production was broken.

## Changes

- **`src/services/TestDataService.ts`** — `createDigitalProduct()` now passes `{ type: 'digital', ...overrides }` to `createBasicProduct()`, so digital products are created with the correct type. Placing `...overrides` last keeps caller-supplied overrides authoritative.
- **`src/types/ShopwareTypes.ts`** — added an optional `type?: string` field to the `Product` type so the new property is type-safe.

## Impact

Any test using `createDigitalProduct` now works with a valid, production-like digital product instead of a mistyped one.

## Verification

- ✅ `npm run build` completes successfully.
- ✅ Ran the tests covering `createDigitalProduct` against the platform — all pass.