### PR TITLE
feat(checkout): support auto-confirmed terms on checkout confirm page

### DIFF
--- a/src/locales/de/storefront/checkout.json
+++ b/src/locales/de/storefront/checkout.json
@@ -32,7 +32,8 @@
         "completeOrder": "Bestellung abschließen",
         "submitOrder": "Zahlungspflichtig bestellen",
         "termsAndConditions": "Ich habe die AGB gelesen und bin mit ihnen einverstanden.",
-        "immediateAccessToDigitalProduct": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt."
+        "immediateAccessToDigitalProduct": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt.",
+        "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere AGB und die Widerrufsbelehrung."
     },
     "finish": {
         "thankYouForOrder": "Vielen Dank für Ihre Bestellung"

--- a/src/locales/en/storefront/checkout.json
+++ b/src/locales/en/storefront/checkout.json
@@ -26,7 +26,8 @@
         "completeOrder": "Complete order",
         "submitOrder": "Submit order",
         "termsAndConditions": "I have read and accepted the general terms and conditions.",
-        "immediateAccessToDigitalProduct": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel."
+        "immediateAccessToDigitalProduct": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel.",
+        "autoConfirmTermsText": "By placing your order you accept our Terms and Conditions and cancellation policy."
     },
     "finish": {
         "thankYouForOrder": "Thank you for your order"

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -9,6 +9,7 @@ export class CheckoutConfirm implements PageObject {
     public readonly grandTotalPrice: Locator;
     public readonly taxPrice: Locator;
     public readonly submitOrderButton: Locator;
+    public readonly termsAutoConfirmedText: Locator;
 
     /**
      * Payment and Shipping options
@@ -54,6 +55,7 @@ export class CheckoutConfirm implements PageObject {
         this.shippingExpress = page.getByLabel(translate("storefront:checkout:common.express"));
 
         this.cartLineItemImages = page.locator(".line-item-img-link");
+        this.termsAutoConfirmedText = page.locator(".checkout-confirm-tos-information");
     }
 
     url() {

--- a/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
+++ b/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
@@ -6,8 +6,10 @@ export const ConfirmTermsAndConditions = base.extend<{ ConfirmTermsAndConditions
     ConfirmTermsAndConditions: async ({ ShopCustomer, StorefrontCheckoutConfirm }, use) => {
         const task = () => {
             return async function ConfirmTermsAndConditions() {
-                await ShopCustomer.presses(StorefrontCheckoutConfirm.termsAndConditionsCheckbox);
-                await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeChecked();
+                if (await StorefrontCheckoutConfirm.termsAndConditionsCheckbox.isVisible()) {
+                    await ShopCustomer.presses(StorefrontCheckoutConfirm.termsAndConditionsCheckbox);
+                    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeChecked();
+                }
             };
         };
 

--- a/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
+++ b/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
@@ -9,6 +9,8 @@ export const ConfirmTermsAndConditions = base.extend<{ ConfirmTermsAndConditions
                 if (await StorefrontCheckoutConfirm.termsAndConditionsCheckbox.isVisible()) {
                     await ShopCustomer.presses(StorefrontCheckoutConfirm.termsAndConditionsCheckbox);
                     await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeChecked();
+                } else {
+                    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAutoConfirmedText).toBeVisible();
                 }
             };
         };


### PR DESCRIPTION
### Why

From v6.8 (`V6_8_0_0`) the checkout confirm page no longer shows a mandatory T&C checkbox by default — it's replaced by an auto-confirm summary line. The shared `ConfirmTermsAndConditions` task pressed a checkbox that no longer exists, which broke every checkout spec on the next-major run.

### What

- `ConfirmTermsAndConditions` is now **presence-aware**:
  - **checkbox visible** (≤6.7, or v6.8 with `core.cart.showTosCheckbox=true`) → press it and assert it's checked, exactly as before.
  - **checkbox absent** (v6.8 default) → assert the auto-confirm summary line (`termsAutoConfirmedText`) is visible instead.
- Add `CheckoutConfirm.termsAutoConfirmedText` locator (`.checkout-confirm-tos-information`).
- Add `autoConfirmTermsText` snippet (en/de) so specs can assert the new summary text.

Consumed by a platform acceptance spec verifying the v6.8 behaviour (shopware/shopware#18176).

### Verified

Ran every spec that calls `ConfirmTermsAndConditions()` against both versions — all green:

- **v6.8.0** (`FEATURE_ALL=major`): checkbox absent → task no-ops, checkout completes.
- **Current / lower version** (`V6_8_0_0` off): checkbox present → task presses and asserts it as before.

So the change is backward compatible: no behavioural difference on lower versions, and the next-major checkout specs pass again.