### PR TITLE
fix: default digital products to maxPurchase 1 and assert quantity selector visibility

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -237,13 +237,17 @@ export class TestDataService {
      * Creates a digital product with a text file as its download.
      * The product will be added to the default sales channel category if configured.
      *
+     * Digital products default to `maxPurchase: 1`, mirroring the Administration
+     * which forces this limit when a product is created as a digital type.
+     * Pass `maxPurchase` in the overrides to change it.
+     *
      * @param content - The content of the text file for the product download.
      * @param overrides - Specific data overrides that will be applied to the product data struct.
      * @param taxId - The uuid of the tax rule to use for the product pricing.
      * @param currencyId - The uuid of the currency to use for the product pricing.
      */
     async createDigitalProduct(content = "Lorem ipsum dolor", overrides: Partial<Product> = {}, taxId = this.defaultTaxId, currencyId = this.defaultCurrencyId): Promise<Product> {
-        const product = await this.createBasicProduct({ type: 'digital', ...overrides }, taxId, currencyId);
+        const product = await this.createBasicProduct({ type: "digital", maxPurchase: 1, ...overrides }, taxId, currencyId);
         const media = await this.createMediaTXT(content);
 
         await this.assignProductDownload(product.id, media.id);

--- a/src/tasks/shop-customer/Product/AddProductToCart.ts
+++ b/src/tasks/shop-customer/Product/AddProductToCart.ts
@@ -7,9 +7,10 @@ export const AddProductToCart = base.extend<{ AddProductToCart: Task }, FixtureT
     AddProductToCart: async ({ ShopCustomer, StorefrontProductDetail }, use) => {
         const task = (ProductData: Product, quantity = "1") => {
             return async function AddProductToCart() {
-                // The storefront hides the quantity selector for digital products with a
-                // fixed quantity (maxPurchase === 1); normal products always show it.
-                const showsQuantitySelect = !(ProductData.type === "digital" && ProductData.maxPurchase === 1);
+                // Download products (type on 6.7+, is-download state on 6.5/6.6) with a
+                // fixed quantity hide the selector; normal products always show it.
+                const isDownloadProduct = ProductData.type === "digital" || (ProductData.states ?? []).includes("is-download");
+                const showsQuantitySelect = !(isDownloadProduct && ProductData.maxPurchase === 1);
 
                 if (showsQuantitySelect) {
                     await ShopCustomer.expects(StorefrontProductDetail.quantitySelect).toBeVisible();

--- a/src/tasks/shop-customer/Product/AddProductToCart.ts
+++ b/src/tasks/shop-customer/Product/AddProductToCart.ts
@@ -7,7 +7,16 @@ export const AddProductToCart = base.extend<{ AddProductToCart: Task }, FixtureT
     AddProductToCart: async ({ ShopCustomer, StorefrontProductDetail }, use) => {
         const task = (ProductData: Product, quantity = "1") => {
             return async function AddProductToCart() {
-                await ShopCustomer.fillsIn(StorefrontProductDetail.quantitySelect, quantity);
+                // The storefront hides the quantity selector for digital products with a
+                // fixed quantity (maxPurchase === 1); normal products always show it.
+                const showsQuantitySelect = !(ProductData.type === "digital" && ProductData.maxPurchase === 1);
+
+                if (showsQuantitySelect) {
+                    await ShopCustomer.expects(StorefrontProductDetail.quantitySelect).toBeVisible();
+                    await ShopCustomer.fillsIn(StorefrontProductDetail.quantitySelect, quantity);
+                } else {
+                    await ShopCustomer.expects(StorefrontProductDetail.quantitySelect).toBeHidden();
+                }
                 await ShopCustomer.presses(StorefrontProductDetail.addToCartButton);
 
                 await ShopCustomer.expects(StorefrontProductDetail.offCanvasCartTitle).toBeVisible();


### PR DESCRIPTION
## Description

`createDigitalProduct()` now defaults `maxPurchase: 1`, matching what the Administration does when a product is created as a digital type. Previously fixture-created digital products had no purchase limit, so the storefront rendered a quantity selector and allowed buying more than one — unlike real digital products.

`AddProductToCart` now derives whether the storefront should show the quantity selector (`type === "digital" && maxPurchase === 1` → hidden) and asserts it: **visible** for normal products (then fills the quantity), **hidden** for fixed-quantity digital products (adds a single unit). This mirrors the storefront's `showQuantitySelect` rule in `buy-widget-form.html.twig`.

Callers can still override via `createDigitalProduct(content, { maxPurchase: N })`.

## Verification

- `CheckoutWithDigitalProduct.spec.ts` passes (digital → selector hidden)
- `RegisteredUserBuysProduct.spec.ts` passes (normal → selector visible)