### PR TITLE
fix(checkout): await terms section render in ConfirmTermsAndConditions

### DIFF
--- a/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
+++ b/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
@@ -6,6 +6,9 @@ export const ConfirmTermsAndConditions = base.extend<{ ConfirmTermsAndConditions
     ConfirmTermsAndConditions: async ({ ShopCustomer, StorefrontCheckoutConfirm }, use) => {
         const task = () => {
             return async function ConfirmTermsAndConditions() {
+                // Wait for the terms section to render before the non-waiting isVisible() check below.
+                await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox.or(StorefrontCheckoutConfirm.termsAutoConfirmedText).first()).toBeVisible();
+
                 if (await StorefrontCheckoutConfirm.termsAndConditionsCheckbox.isVisible()) {
                     await ShopCustomer.presses(StorefrontCheckoutConfirm.termsAndConditionsCheckbox);
                     await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeChecked();


### PR DESCRIPTION
## Problem

`ConfirmTermsAndConditions` fails on any checkout where the terms **checkbox** is present but renders a moment after the task runs — the test wrongly waits for `.checkout-confirm-tos-information` and times out:

​```
Error: expect(locator).toBeVisible() failed
Locator: locator('.checkout-confirm-tos-information')
Timeout: 15000ms
Error: element(s) not found
​```

This surfaced as a broad, deterministic failure of B2B checkout/subscription tests in SwagCommercial after bumping the suite to 12.14.0 (shopware/SwagCommercial#3368).

## Root cause

#659 replaced the auto-waiting checkbox click with a **non-waiting** `isVisible()` gate:

​```ts
// before (#659’s parent)
await ShopCustomer.presses(termsAndConditionsCheckbox);          // click auto-waits for the element
await ShopCustomer.expects(termsAndConditionsCheckbox).toBeChecked();

// after (#659)
if (await termsAndConditionsCheckbox.isVisible()) { … }          // isVisible() does NOT wait
else { await expects(termsAutoConfirmedText).toBeVisible() }     // .checkout-confirm-tos-information
​```

The storefront confirm page renders **either** a terms checkbox **or** the auto-confirmed-terms text (`.checkout-confirm-tos-information`) — never both, and #659’s two branches mirror that correctly. But `locator.isVisible()` is an instantaneous, non-retrying snapshot. When the task runs right after the checkout navigation, the checkbox isn’t painted yet, so `isVisible()` returns a **false negative**, the code enters the `else` branch, and waits 15s for an element a checkbox-mode checkout never renders. The old `presses()` tolerated the late render because a click auto-waits.

## Fix

Add a web-first assertion that lets the terms section settle into one of its two states before the `isVisible()` decision:

​```ts
await ShopCustomer.expects(
    termsAndConditionsCheckbox.or(termsAutoConfirmedText).first()
).toBeVisible();
​```

Both modes remain correct: checkbox mode → wait, then tick; auto-confirm mode →
wait, then assert the text.

## Verification

- Reproduced against a local platform (SwagCommercial `B2B/EmployeeManagement`):  **6 failed → 0 failed** with this change (13 passed / 1 skipped).
- A/B confirmed: the failing test passes on 12.13.4, fails on 12.14.0, passes again with this fix (built via `npm pack` and installed into the consumer).

## Follow-up

Adding a regression test that drives `ConfirmTermsAndConditions` through a **checkbox-mode** checkout would prevent this path from regressing again — #659 was validated only against the auto-confirm path.

Refs #659