### PR TITLE
fix: expose is-download state from createDigitalProduct for 6.5/6.6 detection

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -252,7 +252,9 @@ export class TestDataService {
 
         await this.assignProductDownload(product.id, media.id);
 
-        return product;
+        // Expose the IS_DOWNLOAD state so consumers detect a download product on 6.5/6.6,
+        // where `type` is not backfilled to "digital".
+        return { ...product, states: [...(product.states ?? []), "is-download"] };
     }
 
     /**

--- a/tests/TestDataService/TestDataService.spec.ts
+++ b/tests/TestDataService/TestDataService.spec.ts
@@ -59,6 +59,7 @@ test("Data Service", async ({ TestDataService, AdminApiContext }) => {
 
     const digitalProduct = await TestDataService.createDigitalProduct("Test Test", { description: "You can download me." });
     expect(digitalProduct.description).toEqual("You can download me.");
+    expect(digitalProduct.states).toContain("is-download");
 
     const propertyGroup = await TestDataService.createColorPropertyGroup();
     expect(propertyGroup.description).toEqual("Color");


### PR DESCRIPTION
## Why

`AddProductToCart` decides whether the product-detail quantity selector should be visible by detecting download products:

```ts
const isDownloadProduct = ProductData.type === "digital" || (ProductData.states ?? []).includes("is-download");
```

The `is-download` branch is meant to cover **6.5/6.6**, where the product `type` is not backfilled to `"digital"`. But it never actually worked, because `createDigitalProduct` returns the product **snapshot taken before the download is assigned** and never sets `states`:

```ts
const product = await this.createBasicProduct({ type: "digital", maxPurchase: 1, ...overrides }, ...);
await this.assignProductDownload(product.id, media.id); // download added AFTER
return product;                                         // pre-download snapshot, no states
```

So on 6.5/6.6 neither signal is present → the product is misclassified as a normal product → `AddProductToCart` wrongly expects the quantity selector to be **visible**, while the storefront correctly **hides** it for a download product, and the assertion fails with `element(s) not found`.

This is exactly what breaks the digital-product checkout test on the 6.6.x line (e.g. shopware/shopware#18826), while trunk/6.7 passes only because `type === "digital"` round-trips there.

## What

Return the product with the `IS_DOWNLOAD` state set, so download detection works on **all** supported versions (6.5/6.6 via the state, 6.7 via `type`). The fixture already knows it attached a download, so it surfaces that state deterministically instead of relying on a re-fetch of a runtime-computed field.

## Tested

- Added a regression assertion in `tests/TestDataService/TestDataService.spec.ts` (`createDigitalProduct(...).states` contains `is-download`) — fails on the old code, passes now.
- `typecheck`, `oxlint --type-aware`, `oxfmt` all green.
- No behaviour change on 6.7 (detection was already true there via `type`).
- **Verified against a real Shopware 6.6.10.13 instance** with a digital-product `AddProductToCart` flow (A/B):
  - Baseline `12.14.1` (without this change): fails with `locator('.buy-widget:not(.d-none)').getByLabel('Quantity')` → `element(s) not found` — the same failure seen on the 6.6.x backport (shopware/shopware#18826).
  - This branch: passes. Detection succeeds via the `is-download` state, with no dependency on the digital `type` (which does not exist on ≤6.6).

> Note: on 6.6 and below the digital-product `type` is not available, so backporting shopware/shopware#16652 is not a viable fix there. This state-based change is the version-agnostic solution for those branches.

