### PR TITLE
feat: reuse one admin session per worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "format": "oxfmt --write .",
         "typecheck": "tsgo --noEmit",
         "build": "unbuild",
-        "prepare": "lefthook install",
+        "prepare": "lefthook install && npm run build",
         "prepublishOnly": "npm run build"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "format": "oxfmt --write .",
         "typecheck": "tsgo --noEmit",
         "build": "unbuild",
-        "prepare": "lefthook install && npm run build",
+        "prepare": "(lefthook install || true) && npm run build",
         "prepublishOnly": "npm run build"
     },
     "dependencies": {

--- a/src/fixtures/DefaultSalesChannel.ts
+++ b/src/fixtures/DefaultSalesChannel.ts
@@ -4,7 +4,7 @@ import type { Customer, SalesChannel } from "../types/ShopwareTypes";
 import type { components } from "@shopware/api-client/admin-api-types";
 import { getCountryAddressData } from "../services/ShopwareDataHelpers";
 
-interface StoreBaseConfig {
+export interface StoreBaseConfig {
     storefrontTypeId: string;
     currentLocaleId: string;
     currentLanguageId: string;

--- a/src/fixtures/HelperFixtures.ts
+++ b/src/fixtures/HelperFixtures.ts
@@ -26,7 +26,11 @@ export interface HelperFixtureTypes {
 export const test = base.extend<NonNullable<unknown>, FixtureTypes>({
     IdProvider: [
         async ({}, use, workerInfo) => {
-            const seed = process.env.SHOPWARE_ACCESS_KEY_ID || process.env.SHOPWARE_ADMIN_PASSWORD || "test-suite";
+            const baseSeed = process.env.SHOPWARE_ACCESS_KEY_ID || process.env.SHOPWARE_ADMIN_PASSWORD || "test-suite";
+            // ATS_ID_SEED separates the worker-derived stable ids of concurrent suite
+            // runs against the same shop (e.g. Platform and Commercial in parallel CI
+            // jobs), which would otherwise contend for the same worker sales channels.
+            const seed = process.env.ATS_ID_SEED ? `${process.env.ATS_ID_SEED}:${baseSeed}` : baseSeed;
             const idProvider = new IdProvider(workerInfo.parallelIndex, seed);
 
             await use(idProvider);

--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -1,13 +1,20 @@
 import { test as base, expect } from "@playwright/test";
 import type { Page, BrowserContext } from "playwright-core";
 import type { FixtureTypes } from "../types/FixtureTypes";
+import type { User } from "../types/ShopwareTypes";
 import { isThemeCompiled } from "../services/ShopInfo";
 import { clearDelayedCache } from "../services/Cache";
-import { createNewAdminPageContext, loginToAdministration } from "../services/AdminLoginHelper";
+import { createNewAdminPageContext, hideSymfonyToolbarOnReload, loginToAdministration } from "../services/AdminLoginHelper";
 import { LanguageHelper, setCurrentContext } from "../services/LanguageHelper";
 import { getLocale } from "../services/ShopwareDataHelpers";
 
+export interface AdminSession {
+    context: BrowserContext;
+    user: User;
+}
+
 export interface PageContextTypes {
+    AdminSession: AdminSession;
     AdminPage: Page;
     StorefrontPage: Page;
     InstallPage: Page;
@@ -15,41 +22,66 @@ export interface PageContextTypes {
     context: BrowserContext;
 }
 
-export const test = base.extend<FixtureTypes>({
-    AdminPage: async ({ IdProvider, AdminApiContext, SalesChannelBaseConfig, browser, CustomTranslationResources }, use) => {
+type PageContextWorkerFixtures = Pick<FixtureTypes, "AdminSession" | "IdProvider" | "AdminApiContext" | "SalesChannelBaseConfig">;
+
+export const test = base.extend<Omit<FixtureTypes, "AdminSession">, PageContextWorkerFixtures>({
+    AdminSession: [
+        async ({ IdProvider, AdminApiContext, SalesChannelBaseConfig, browser }, use) => {
+            const { id, uuid } = IdProvider.getIdPair();
+
+            const adminUser: User = {
+                id: uuid,
+                username: `admin_${id}`,
+                firstName: `${id} admin`,
+                lastName: `${id} admin`,
+                localeId: SalesChannelBaseConfig.currentLocaleId,
+                email: `admin_${id}@example.com`,
+                timeZone: "Europe/Berlin",
+                password: "shopware",
+                admin: true,
+            };
+
+            const response = await AdminApiContext.post("user", {
+                data: adminUser,
+            });
+
+            expect(response.ok()).toBeTruthy();
+
+            // Log in through the UI once per worker. Tests get fresh pages within this
+            // authenticated context instead of repeating the expensive admin login.
+            const loginPage = await loginToAdministration(await createNewAdminPageContext(browser, SalesChannelBaseConfig), adminUser, AdminApiContext);
+            const context = loginPage.context();
+            await loginPage.close();
+
+            await use({ context, user: adminUser });
+
+            await context.close();
+
+            // Cleanup created user
+            await AdminApiContext.delete(`user/${uuid}`);
+        },
+        { scope: "worker" },
+    ],
+
+    AdminPage: async ({ AdminSession, CustomTranslationResources }, use) => {
         const locale = getLocale();
         const languageHelper = await LanguageHelper.createInstance(locale, CustomTranslationResources);
 
-        const { id, uuid } = IdProvider.getIdPair();
+        // A new page within the shared worker context reuses the session and the browser
+        // cache, but still gives every test an isolated DOM and JavaScript world.
+        const page = await AdminSession.context.newPage();
+        hideSymfonyToolbarOnReload(page);
 
-        const adminUser = {
-            id: uuid,
-            username: `admin_${id}`,
-            firstName: `${id} admin`,
-            lastName: `${id} admin`,
-            localeId: SalesChannelBaseConfig.currentLocaleId,
-            email: `admin_${id}@example.com`,
-            timezone: "Europe/Berlin",
-            password: "shopware",
-            admin: true,
-        };
-
-        const response = await AdminApiContext.post("user", {
-            data: adminUser,
-        });
-
-        expect(response.ok()).toBeTruthy();
-
-        const page = await loginToAdministration(await createNewAdminPageContext(browser, SalesChannelBaseConfig), adminUser, AdminApiContext);
+        await page.goto("./");
+        await page.waitForURL((url) => url.hash.startsWith("#/") && !url.hash.startsWith("#/login"));
+        await expect(page.getByText(AdminSession.user.firstName + " " + AdminSession.user.lastName).first()).toBeVisible({ timeout: 60000 });
+        await expect(page.locator(".sw-skeleton")).toHaveCount(0);
 
         LanguageHelper.setForContext(page.context() as unknown as Record<string, unknown>, languageHelper);
         setCurrentContext(page.context() as unknown as Record<string, unknown>);
         await use(page);
         await page.close();
         setCurrentContext(null);
-
-        // Cleanup created user
-        await AdminApiContext.delete(`user/${uuid}`);
     },
 
     StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, StoreApiContext, InstanceMeta, CustomTranslationResources }, use) => {

--- a/src/services/AdminLoginHelper.ts
+++ b/src/services/AdminLoginHelper.ts
@@ -18,11 +18,35 @@ export async function createNewAdminPageContext(browser: Browser, SalesChannelBa
         baseURL: SalesChannelBaseConfig.adminUrl,
         serviceWorkers: "block",
     });
+    // Install the mocks on the context, so they already apply to the initial page load
+    // and to every page that is opened within this context later on.
+    await mockApiCalls(context);
     const adminPage = await context.newPage();
     await adminPage.goto("#/login");
-    await mockApiCalls(adminPage);
 
     return adminPage;
+}
+
+/**
+ * Hides the Symfony debug toolbar after every reload of the given page.
+ * @param page - The Playwright Page instance to patch.
+ */
+export function hideSymfonyToolbarOnReload(page: Page): void {
+    const originalReload = page.reload.bind(page);
+    page.reload = async () => {
+        const res = await originalReload();
+        await page.addStyleTag({
+            content: `
+                .sf-toolbar {
+                    width: 0 !important;
+                    height: 0 !important;
+                    display: none !important;
+                    pointer-events: none !important;
+                }
+                `.trim(),
+        });
+        return res;
+    };
 }
 
 /**
@@ -57,21 +81,7 @@ export async function loginToAdministration(adminLoginPage: Page, merchant: User
     await Promise.all(jsLoadingPromises);
 
     // Override page reload to also remove the Symfony toolbar
-    const originalReload = adminLoginPage.reload.bind(adminLoginPage);
-    adminLoginPage.reload = async () => {
-        const res = await originalReload();
-        await adminLoginPage.addStyleTag({
-            content: `
-                .sf-toolbar {
-                    width: 0 !important;
-                    height: 0 !important;
-                    display: none !important;
-                    pointer-events: none !important;
-                }
-                `.trim(),
-        });
-        return res;
-    };
+    hideSymfonyToolbarOnReload(adminLoginPage);
 
     await clearDelayedCache(AdminApiContext);
 

--- a/src/services/ApiMocks.ts
+++ b/src/services/ApiMocks.ts
@@ -1,6 +1,6 @@
-import type { Page } from "playwright-core";
+import type { BrowserContext, Page } from "playwright-core";
 
-export async function mockApiCalls(page: Page) {
+export async function mockApiCalls(page: Page | BrowserContext) {
     await page.route("**/api/notification/message*", (route) =>
         route.fulfill({
             status: 200,

--- a/src/services/IdProvider.ts
+++ b/src/services/IdProvider.ts
@@ -40,7 +40,10 @@ export class IdProvider {
         bytes[8] = 0x80;
 
         return {
-            id: `${this.workerIndex}`,
+            // Derived from the hash like the uuid, so ids (and names/emails built from
+            // them, e.g. the worker customer email) stay distinct between runs with
+            // different seeds. A plain worker index collides across concurrent suites.
+            id: `${buffer.readUIntBE(16, 6)}`,
             uuid: stringify(bytes).replaceAll("-", ""),
         };
     }


### PR DESCRIPTION
## Why

Every test that touches the Administration creates a fresh admin user and performs a full UI login: new browser context, login form, an explicit wait for every plugin bundle, dashboard render, cache purge. That is 10–20 seconds per test on CI/SaaS, and the platform suite pays it ~90 times per run.

## What changed

- New worker-scoped **`AdminSession`** fixture: one admin user, one UI login per worker.
- **`AdminPage` stays test-scoped**, but now opens a fresh page inside the shared authenticated context. Tests keep an isolated DOM and JavaScript world — they just stop logging in.
- API mocks are installed on the **context before the first navigation** — previously the initial admin page load bypassed them.
- **Git installs work now:** `prepare` builds `dist/`, so consumers can test unreleased branches via `npm install github:shopware/acceptance-test-suite#<branch>`.
- New optional **`ATS_ID_SEED`** env to separate the worker-derived stable ids of concurrent suite runs against the same shop (e.g. Platform and Commercial as parallel CI jobs).
- Bugfix: `getWorkerDerivedStableId` returned the bare worker index as its short id, so derived names/emails (`customer_0@example.com`) collide globally between any two suites pointed at one shop. The id is now derived from the seed hash.
- Bugfix: the admin user struct sent `timezone`; the schema field is `timeZone`, so the timezone was silently never applied.

## What this means for consumers — please review these two semantic changes

1. **Tests within one worker share one admin user.** Server-side per-user state (`user_config`, grid preferences) persists across the tests of a worker. Tests that need a fresh, specific, or permission-restricted user should create one and log in via `createNewAdminPageContext` + `loginToAdministration` — an audit of this repo, shopware/platform, and SwagCommercial found every existing ACL/fresh-user test already does exactly that.
2. **The `context` alias now returns the shared worker context.** No current test mutates or closes it. On failure Playwright disposes the worker, so retries always get a completely fresh session.

## Measured

- Local trunk shop: admin fixture per test 1.3–2.7 s → 0.36–1.7 s.
- shopware/saas CI pipeline at identical worker count: Platform suite 16.6 → 9.5 min, Commercial 18.9 → ~14 min — reproduced across multiple runs, with every remaining failure control-tested as pre-existing.

Validated end to end via shopware/saas#748, which installs this branch through the new git-ref mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZJW1coXncj5CUE3AtpyLM