### PR TITLE
fix: resolve price before opening cart offcanvas

### DIFF
--- a/src/tasks/shop-customer/Wishlist/WishlistActions.ts
+++ b/src/tasks/shop-customer/Wishlist/WishlistActions.ts
@@ -8,12 +8,12 @@ export const AddProductToCartFromWishlist = base.extend<{ AddProductToCartFromWi
         const task = (ProductData: Product) => {
             return async function AddProductToCartFromWishlist() {
                 const listedItem = await StorefrontWishlist.getListingItemByProductName(ProductData.name);
+                const expectedPrice = await listedItem.productPrice.innerText();
                 await ShopCustomer.presses(listedItem.productAddToShoppingCart);
                 await StorefrontWishlist.page.waitForResponse((response) => response.url().includes(`checkout/offcanvas`) && response.ok());
                 await ShopCustomer.expects(StorefrontOffCanvasCart.itemCount).toBeVisible();
                 const offcanvasItem = await StorefrontOffCanvasCart.getLineItemByProductNumber(ProductData.productNumber);
                 const itemsPrice = await offcanvasItem.productTotalPriceValue.innerText();
-                const expectedPrice = await listedItem.productPrice.innerText();
                 ShopCustomer.expects(itemsPrice).toBe(expectedPrice);
             };
         };


### PR DESCRIPTION
## Overview

Resolve the expected product price before opening the cart offcanvas.

## Motivation

shopware/shopware#18866 adds `aria-hidden` to elements outside the active offcanvas. As a result, the product price is no longer accessible after the offcanvas opens.

Reading the price before opening the offcanvas fixes the assertion.