### PR TITLE
feat: EU guarantee label 

### DIFF
--- a/src/locales/de/storefront/checkout.json
+++ b/src/locales/de/storefront/checkout.json
@@ -33,7 +33,8 @@
         "submitOrder": "Zahlungspflichtig bestellen",
         "termsAndConditions": "Ich habe die AGB gelesen und bin mit ihnen einverstanden.",
         "immediateAccessToDigitalProduct": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt.",
-        "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere AGB und die Widerrufsbelehrung."
+        "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere AGB und die Widerrufsbelehrung.",
+        "termsAndConditionsWithLegalGuaranteeRights": "Ich habe die AGB gelesen und bin mit ihnen einverstanden und habe meine gesetzlichen Gewährleistungsrechte erkannt."
     },
     "finish": {
         "thankYouForOrder": "Vielen Dank für Ihre Bestellung"

--- a/src/locales/de/storefront/product.json
+++ b/src/locales/de/storefront/product.json
@@ -28,6 +28,8 @@
     "addToCart": "In den Warenkorb",
     "addToWishlist": "Auf die Wunschliste",
     "removeFromWishlist": "Von der Wunschliste entfernen",
+    "garanLabelShowLink": "GARAN-Kennzeichnung anzeigen",
+    "garanLabelHideLink": "GARAN-Kennzeichnung ausblenden",
     "deliveryTime": "Lieferzeit",
     "quantity": "Anzahl",
     "review": {

--- a/src/locales/en/storefront/checkout.json
+++ b/src/locales/en/storefront/checkout.json
@@ -27,7 +27,8 @@
         "submitOrder": "Submit order",
         "termsAndConditions": "I have read and accepted the general terms and conditions.",
         "immediateAccessToDigitalProduct": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel.",
-        "autoConfirmTermsText": "By placing your order you accept our Terms and Conditions and cancellation policy."
+        "autoConfirmTermsText": "By placing your order you accept our Terms and Conditions and cancellation policy.",
+        "termsAndConditionsWithLegalGuaranteeRights": "I have read and accepted the general terms and conditions and acknowledged my legal guarantee rights."
     },
     "finish": {
         "thankYouForOrder": "Thank you for your order"

--- a/src/locales/en/storefront/product.json
+++ b/src/locales/en/storefront/product.json
@@ -3,6 +3,8 @@
     "quantity": "Quantity",
     "addToWishlist": "Add to wishlist",
     "removeFromWishlist": "Remove from wishlist",
+    "garanLabelShowLink": "Show GARAN label",
+    "garanLabelHideLink": "Hide GARAN label",
     "deliveryTime": "Ready to ship today,\\nDelivery time appr. 1-3 workdays",
     "review": {
         "tabTitle": "Reviews",

--- a/src/page-objects/storefront/AccountOrder.ts
+++ b/src/page-objects/storefront/AccountOrder.ts
@@ -30,7 +30,7 @@ export class AccountOrder extends BaseAccount {
         this.noOrdersAlert = page.locator(".alert-warning");
     }
 
-    async getOrderByOrderNumber(orderNumber: string): Promise<Record<string, Locator>> {
+    async getOrderByOrderNumber(orderNumber: string, productNumber?: string): Promise<Record<string, Locator>> {
         const orderItem = this.page.getByRole("listitem").getByLabel(`${translate("storefront:account:orders.orderNumber")} ${orderNumber}`);
         const orderStatus = orderItem.locator(".order-table-header-order-status");
         const orderStatusLink = orderStatus.getByRole("link");
@@ -51,7 +51,7 @@ export class AccountOrder extends BaseAccount {
         const shippingCosts = orderItem.locator(`dt:text-matches('${translate("storefront:account:orders.shippingCosts")}') + dd`);
         const totalGross = orderItem.locator(`dt:text-matches('${translate("storefront:account:orders.totalGross")}') + dd`);
 
-        return {
+        const locators: Record<string, Locator> = {
             orderStatus: orderStatus,
             orderStatusLink: orderStatusLink,
             orderHeading: orderHeading,
@@ -69,6 +69,16 @@ export class AccountOrder extends BaseAccount {
             shippingCosts: shippingCosts,
             totalGross: totalGross,
         };
+
+        if (productNumber) {
+            const lineItem = orderItem.locator(".line-item-product", { hasText: productNumber });
+            locators.lineItem = lineItem;
+            locators.productNameLabel = lineItem.locator(".line-item-label");
+            locators.productNumberLabel = lineItem.locator(".line-item-product-number");
+            locators.lineItemGaranLabel = lineItem.locator(".line-item-garan-label");
+        }
+
+        return locators;
     }
 
     url() {

--- a/src/page-objects/storefront/CheckoutConfirm.ts
+++ b/src/page-objects/storefront/CheckoutConfirm.ts
@@ -5,11 +5,15 @@ import { translate } from "../../services/LanguageHelper";
 export class CheckoutConfirm implements PageObject {
     public readonly headline: Locator;
     public readonly termsAndConditionsCheckbox: Locator;
+    public readonly termsAndConditionsWithLegalGuaranteeRightsLabel: Locator;
+    public readonly termsAndConditionsWithLegalGuaranteeRightsCheckbox: Locator;
     public readonly immediateAccessToDigitalProductCheckbox: Locator;
     public readonly grandTotalPrice: Locator;
     public readonly taxPrice: Locator;
     public readonly submitOrderButton: Locator;
     public readonly termsAutoConfirmedText: Locator;
+    public readonly legalGuaranteeNoticeLink: Locator;
+    public readonly lineItemGaranLabel: Locator;
 
     /**
      * Payment and Shipping options
@@ -56,6 +60,11 @@ export class CheckoutConfirm implements PageObject {
 
         this.cartLineItemImages = page.locator(".line-item-img-link");
         this.termsAutoConfirmedText = page.locator(".checkout-confirm-tos-information");
+
+        this.termsAndConditionsWithLegalGuaranteeRightsCheckbox = page.locator("#tos");
+        this.termsAndConditionsWithLegalGuaranteeRightsLabel = page.getByLabel(translate("storefront:checkout:confirm.termsAndConditionsWithLegalGuaranteeRights"));
+        this.legalGuaranteeNoticeLink = page.locator("#legalGuaranteeNoticeModal a");
+        this.lineItemGaranLabel = page.locator(".line-item-garan-label");
     }
 
     url() {

--- a/src/page-objects/storefront/OffCanvasCart.ts
+++ b/src/page-objects/storefront/OffCanvasCart.ts
@@ -50,6 +50,7 @@ export class OffCanvasCart implements PageObject {
         const removeButton = lineItem.locator(".line-item-remove-button");
         const wishlistAddedButton = lineItem.locator(".product-wishlist-added");
         const wishlistNotAddedButton = lineItem.locator(".product-wishlist-not-added");
+        const lineItemGaranLabel = lineItem.locator(".line-item-garan-label");
 
         return {
             lineItemImage: lineItemImage,
@@ -64,6 +65,7 @@ export class OffCanvasCart implements PageObject {
             removeButton: removeButton,
             wishlistAddedButton: wishlistAddedButton,
             wishlistNotAddedButton: wishlistNotAddedButton,
+            lineItemGaranLabel: lineItemGaranLabel,
         };
     }
 }

--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -34,6 +34,12 @@ export class ProductDetail implements PageObject {
     public readonly productName: Locator;
     public readonly productDescriptionTitle: Locator;
 
+    public readonly garanNestedLabel: Locator;
+    public readonly garanFullLabel: Locator;
+    public readonly showGaranLabelButton: Locator;
+    public readonly hideGaranLabelButton: Locator;
+    public readonly offCanvasLineItemGaranLabel: Locator;
+
     //Reviews Tab
     public readonly reviewsTab: Locator;
     public readonly reviewTeaserButton: Locator;
@@ -99,6 +105,12 @@ export class ProductDetail implements PageObject {
         this.productName = page.locator(".product-detail-name");
         this.productDescriptionTitle = page.locator(".product-detail-description-title");
 
+        this.garanNestedLabel = page.locator(".product-detail-garan-label");
+        this.garanFullLabel = page.locator(".product-detail-garan-label-full");
+        this.showGaranLabelButton = page.getByRole("button", { name: translate("storefront:product:garanLabelShowLink") });
+        this.hideGaranLabelButton = page.getByRole("button", { name: translate("storefront:product:garanLabelHideLink") });
+        this.offCanvasLineItemGaranLabel = this.offCanvasCart.locator(".line-item-garan-label");
+
         this.productReviewRating = page.locator(".product-detail-reviews .product-review-rating");
         this.productReviewsLink = page.locator(".product-detail-reviews .product-detail-reviews-link");
         this.reviewsTab = this.page.getByRole("tab", { name: translate("storefront:product:review.tabTitle") });
@@ -122,7 +134,7 @@ export class ProductDetail implements PageObject {
         this.reviewItemTitle = this.page.locator(".product-detail-review-item-title");
         this.reviewItemContent = this.page.locator(".product-detail-review-item-content");
         this.reviewSubmitMessage = this.page.getByText(translate("storefront:product:review.submitMessage"));
-        this.reviewTabLoadingIcon = this.page.locator('.element-loader-backdrop').locator('.loader');
+        this.reviewTabLoadingIcon = this.page.locator(".element-loader-backdrop").locator(".loader");
     }
 
     async getReviewFilterRowOptionsByName(filterOptionName: string) {

--- a/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
+++ b/src/tasks/shop-customer/Checkout/ConfirmTermsAndConditions.ts
@@ -2,7 +2,13 @@ import { test as base } from "@playwright/test";
 import type { Task } from "../../../types/Task";
 import type { FixtureTypes } from "../../../types/FixtureTypes";
 
-export const ConfirmTermsAndConditions = base.extend<{ ConfirmTermsAndConditions: Task }, FixtureTypes>({
+export const ConfirmTermsAndConditions = base.extend<
+    {
+        ConfirmTermsAndConditions: Task;
+        ConfirmTermsAndConditionsWithLegalGuaranteeRights: Task;
+    },
+    FixtureTypes
+>({
     ConfirmTermsAndConditions: async ({ ShopCustomer, StorefrontCheckoutConfirm }, use) => {
         const task = () => {
             return async function ConfirmTermsAndConditions() {
@@ -15,6 +21,23 @@ export const ConfirmTermsAndConditions = base.extend<{ ConfirmTermsAndConditions
                 } else {
                     await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAutoConfirmedText).toBeVisible();
                 }
+            };
+        };
+
+        await use(task);
+    },
+    /**
+     * TOS acceptance when `core.cart.showLegalGuaranteeNotice` is enabled.
+     * The accessible name changes, so interaction uses the stable #tos input.
+     */
+    ConfirmTermsAndConditionsWithLegalGuaranteeRights: async ({ ShopCustomer, StorefrontCheckoutConfirm }, use) => {
+        const task = () => {
+            return async function ConfirmTermsAndConditionsWithLegalGuaranteeRights() {
+                await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsWithLegalGuaranteeRightsLabel).toBeVisible();
+                const tosCheckbox = StorefrontCheckoutConfirm.termsAndConditionsWithLegalGuaranteeRightsCheckbox;
+                await ShopCustomer.expects(tosCheckbox).toBeVisible();
+                await tosCheckbox.check();
+                await ShopCustomer.expects(tosCheckbox).toBeChecked();
             };
         };
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware core adds EU GARAN durability labels and an optional legal guarantee notice on checkout (core.cart.showLegalGuaranteeNotice). Existing ATS page objects/tasks only know the classic TOS checkbox and have no locators for GARAN / guarantee-rights UI

### 2. What does this change do, exactly?
It extends ATS (no platform product logic):
- Locales (EN/DE): GARAN show/hide button texts; TOS string with legal guarantee rights.
- ProductDetail: nested/full GARAN labels, show/hide buttons, off-canvas line-item GARAN.
- OffCanvasCart / CheckoutConfirm / AccountOrder: `.line-item-garan-label`; checkout TOS+guarantee locators + Your Europe modal link; optional productNumber on `getOrderByOrderNumber` for product-scoped order line items.
- `ConfirmTermsAndConditionsWithLegalGuaranteeRights`: new task for notice-enabled TOS via `#tos` (classic ConfirmTermsAndConditions unchanged).

### 3. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/pull/19081