### PR TITLE
fix: wait for storefront JavaScript compilation

### DIFF
--- a/src/fixtures/PageContexts.ts
+++ b/src/fixtures/PageContexts.ts
@@ -84,7 +84,7 @@ export const test = base.extend<Omit<FixtureTypes, "AdminSession">, PageContextW
         setCurrentContext(null);
     },
 
-    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, StoreApiContext, InstanceMeta, CustomTranslationResources }, use) => {
+    StorefrontPage: async ({ DefaultSalesChannel, SalesChannelBaseConfig, browser, AdminApiContext, StoreApiContext, CustomTranslationResources }, use) => {
         const { url, salesChannel } = DefaultSalesChannel;
         const locale = getLocale();
         const languageHelper = await LanguageHelper.createInstance(locale, CustomTranslationResources);
@@ -104,17 +104,10 @@ export const test = base.extend<Omit<FixtureTypes, "AdminSession">, PageContextW
         if (!(await isThemeCompiled(StoreApiContext, DefaultSalesChannel.url))) {
             base.slow();
 
-            await AdminApiContext.post(`./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${salesChannel.id}`);
+            await AdminApiContext.post(`./_action/theme/${SalesChannelBaseConfig.defaultThemeId}/assign/${salesChannel.id}?no-queue=true`);
             await clearDelayedCache(AdminApiContext);
 
             page = await context.newPage();
-
-            if (InstanceMeta.isSaaS) {
-                while (!(await isThemeCompiled(StoreApiContext, DefaultSalesChannel.url))) {
-                    await clearDelayedCache(AdminApiContext);
-                    await page.waitForTimeout(4000);
-                }
-            }
         } else {
             page = await context.newPage();
         }

--- a/src/services/ShopInfo.ts
+++ b/src/services/ShopInfo.ts
@@ -15,14 +15,17 @@ export const isThemeCompiled = async (context: StoreApiContext, storefrontUrl: s
 
     const body = (await response.body()).toString();
 
-    const matches = body.match(/.*"(https?:\/\/.*all\.css[^"]*)".*/);
-    if (matches && matches?.length > 1) {
-        const allCssUrl = matches[1];
+    const allCssUrl = body.match(/.*"(https?:\/\/.*all\.css[^"]*)".*/)?.[1];
+    const storefrontJavaScriptUrl = body.match(/.*"(https?:\/\/.*\/js\/storefront\/storefront\.js[^"]*)".*/)?.[1];
 
-        const allCssResponse = await context.get(allCssUrl);
-
-        return allCssResponse.status() < 400;
+    if (!allCssUrl || !storefrontJavaScriptUrl) {
+        return false;
     }
 
-    return false;
+    const assetResponses = await Promise.all([
+        context.get(allCssUrl),
+        context.get(storefrontJavaScriptUrl),
+    ]);
+
+    return assetResponses.every((assetResponse) => assetResponse.status() < 400);
 };

--- a/tests/ThemeTest.spec.ts
+++ b/tests/ThemeTest.spec.ts
@@ -2,7 +2,15 @@ import { test, expect } from "../src/index";
 
 test("Theme compilation.", async ({ StorefrontPage }) => {
     const allCSSResponsePromise = StorefrontPage.waitForResponse(/all\.css/);
+    const storefrontJavaScriptResponsePromise = StorefrontPage.waitForResponse(/\/js\/storefront\/storefront\.js/);
+
     await StorefrontPage.reload();
-    const response = await allCSSResponsePromise;
-    expect(response.status()).toBeLessThan(400);
+
+    const [allCssResponse, storefrontJavaScriptResponse] = await Promise.all([
+        allCSSResponsePromise,
+        storefrontJavaScriptResponsePromise,
+    ]);
+
+    expect(allCssResponse.status()).toBeLessThan(400);
+    expect(storefrontJavaScriptResponse.status()).toBeLessThan(400);
 });


### PR DESCRIPTION
## What?

Require the theme readiness check to validate the main storefront JavaScript as well as CSS. Compile the assigned theme synchronously and remove the SaaS-only cache-clear polling.

## Why?

A page can expose compiled CSS before its storefront JavaScript entry is available. Treating that state as ready lets tests navigate to markup whose plugins cannot initialize.