### PR TITLE
feat: add adminMenuAutomation locator to admin menu page object

### DIFF
--- a/src/page-objects/administration/Dashboard.ts
+++ b/src/page-objects/administration/Dashboard.ts
@@ -12,6 +12,7 @@ export class Dashboard implements PageObject {
     public readonly adminMenuContent: Locator;
     public readonly adminMenuMarketing: Locator;
     public readonly adminMenuExtension: Locator;
+    public readonly adminMenuAutomation: Locator;
     public readonly adminMenuSettings: Locator;
     public readonly adminMenuUserChevron: Locator;
     public readonly adminMenuUserIcon: Locator;
@@ -47,6 +48,7 @@ export class Dashboard implements PageObject {
         this.adminMenuContent = page.locator(".sw-content");
         this.adminMenuMarketing = page.locator(".sw-marketing");
         this.adminMenuExtension = page.locator(".sw-extension");
+        this.adminMenuAutomation = page.locator(".sw-automation");
         this.adminMenuUserChevron = page.locator(".sw-admin-menu__user-actions-indicator");
         this.adminMenuUserIcon = page.locator(".sw-avatar");
         this.adminMenuUserName = page.locator(".sw-admin-menu__user-name");


### PR DESCRIPTION
## Why
The Administration main menu gained a new top-level **Automation** section (Rule Builder, Flow Builder). The `AdminMenu` visual test in shopware/shopware expands every main menu section before taking its screenshot, but there is no page-object locator for the Automation section — so that test is currently skipped (see shopware/shopware#19244).

## What
Adds the `adminMenuAutomation` locator (`.sw-automation`) to the `Dashboard` page object, following the existing `.sw-<module-id>` convention used by the other admin menu locators (`.sw-catalogue`, `.sw-order`, `.sw-extension`, …). The class is derived directly from the module id `sw-automation` by the admin menu component.

## Follow-up
Once released, a follow-up PR in shopware/shopware bumps `@shopware-ag/acceptance-test-suite`, un-skips the `AdminMenu` visual test, adds the Automation click, and regenerates the baseline via the Visual Tests workflow.
