### PR TITLE
fix(tasks): wait for add to cart readiness

### DIFF
--- a/src/page-objects/storefront/ProductDetail.ts
+++ b/src/page-objects/storefront/ProductDetail.ts
@@ -5,6 +5,7 @@ import { translate } from "../../services/LanguageHelper";
 
 export class ProductDetail implements PageObject {
     public readonly addToCartButton: Locator;
+    public readonly addToCartForm: Locator;
     public readonly quantitySelect: Locator;
     public readonly productSingleImage: Locator;
     public readonly productSinglePrice: Locator;
@@ -72,6 +73,7 @@ export class ProductDetail implements PageObject {
         this.page = page;
         this.addToCartButton = page.getByRole("button", { name: translate("storefront:product:addToCart") });
         const form = page.locator(".buy-widget:not(.d-none)");
+        this.addToCartForm = form;
         this.quantitySelect = form.getByLabel(translate("storefront:product:quantity"), { exact: true });
         this.productSingleImage = page.locator(".gallery-slider-single-image");
         this.productSinglePrice = page.locator(".product-detail-price");

--- a/src/tasks/shop-customer/Product/AddProductToCart.ts
+++ b/src/tasks/shop-customer/Product/AddProductToCart.ts
@@ -7,6 +7,8 @@ export const AddProductToCart = base.extend<{ AddProductToCart: Task }, FixtureT
     AddProductToCart: async ({ ShopCustomer, StorefrontProductDetail }, use) => {
         const task = (ProductData: Product, quantity = "1") => {
             return async function AddProductToCart() {
+                await ShopCustomer.expects(StorefrontProductDetail.addToCartForm).toHaveAttribute("data-add-to-cart-ready", "true");
+
                 // Download products (type on 6.7+, is-download state on 6.5/6.6) with a
                 // fixed quantity hide the selector; normal products always show it.
                 const isDownloadProduct = ProductData.type === "digital" || (ProductData.states ?? []).includes("is-download");


### PR DESCRIPTION
## Summary

Wait for the Storefront add-to-cart enhancement to finish initializing before the shared `AddProductToCart` task submits the form.

The task could otherwise submit the native form fallback before the asynchronous Storefront plugins attached their handler, then wait for an offcanvas that cannot appear.

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run build`
