### PR TITLE
chore: expose the shopware-ats skill to Claude Code

### DIFF
--- a/.claude/agents/shopware-ats.md
+++ b/.claude/agents/shopware-ats.md
@@ -1,0 +1,6 @@
+---
+name: shopware-ats
+description: Guide Claude through Shopware ATS work — inspecting, updating, or extending the Shopware Acceptance Test Suite (Playwright specs, fixtures, page objects, tasks, services, types).
+---
+
+Use the shopware-ats skill to inspect, update, or extend the Shopware Acceptance Test Suite.

--- a/.claude/skills/shopware-ats
+++ b/.claude/skills/shopware-ats
@@ -1,0 +1,1 @@
+../../.codex/skills/shopware-ats

--- a/.claude/skills/shopware-ats
+++ b/.claude/skills/shopware-ats
@@ -1,1 +1,0 @@
-../../.codex/skills/shopware-ats

--- a/.claude/skills/shopware-ats/SKILL.md
+++ b/.claude/skills/shopware-ats/SKILL.md
@@ -1,0 +1,1 @@
+../../../.codex/skills/shopware-ats/SKILL.md

--- a/.claude/skills/shopware-ats/references
+++ b/.claude/skills/shopware-ats/references
@@ -1,0 +1,1 @@
+../../../.codex/skills/shopware-ats/references

--- a/.codex/skills/shopware-ats/SKILL.md
+++ b/.codex/skills/shopware-ats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopware-ats
-description: "Work effectively in the Shopware Acceptance Test Suite repository: inspect or modify Playwright specs, merged fixtures, page objects, tasks, service helpers, shared types, and locale-backed assertions. Use when Codex needs to debug a failing ATS test, add or refactor Shopware end-to-end coverage, trace how exported fixtures are wired together, or choose the right file to update in `tests/`, `src/fixtures/`, `src/page-objects/`, `src/tasks/`, `src/services/`, or `src/types/`."
+description: "Work effectively in the Shopware Acceptance Test Suite repository: inspect or modify Playwright specs, merged fixtures, page objects, tasks, service helpers, shared types, and locale-backed assertions. Use when you need to debug a failing ATS test, add or refactor Shopware end-to-end coverage, trace how exported fixtures are wired together, or choose the right file to update in `tests/`, `src/fixtures/`, `src/page-objects/`, `src/tasks/`, `src/services/`, or `src/types/`."
 ---
 
 # Shopware ATS

--- a/USAGE.md
+++ b/USAGE.md
@@ -8,10 +8,13 @@
 ```text
 .
   USAGE.md                              # This file: how humans should use the shopware-ats skill
-.codex/skills/shopware-ats/
-  SKILL.md                              # Loaded by Codex: behavioral rules for the assistant
-  agents/openai.yaml                    # Default prompt metadata
-  references/repo-map.md              # Detailed repository layout and change paths
+.codex/skills/shopware-ats/             # Source of truth
+  SKILL.md                              # Loaded by Codex/Claude: behavioral rules for the assistant
+  agents/openai.yaml                    # Codex-only: agent display name / default prompt metadata
+  references/repo-map.md                # Detailed repository layout and change paths
+.claude/
+  skills/shopware-ats/                  # Mirrors only SKILL.md + references/ (symlinks) — no agents/
+  agents/shopware-ats.md                # Claude-only: equivalent of agents/openai.yaml
 ```
 
 ## Purpose

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,6 +17,16 @@
   agents/shopware-ats.md                # Claude-only: equivalent of agents/openai.yaml
 ```
 
+`.codex/skills/shopware-ats/` holds the real files; `.claude/skills/shopware-ats/` mirrors only the
+tool-agnostic parts (`SKILL.md`, `references/`) via symlinks, so Codex-only metadata (`agents/openai.yaml`)
+never leaks into what Claude sees. Each tool keeps its own agent manifest in its own `agents/` directory.
+
+**If a third tool needs this skill:** we considered moving the shared content (`SKILL.md`, `references/`)
+into a neutral top-level directory (e.g. `skills/shopware-ats/`), with `.codex/skills/shopware-ats` and
+`.claude/skills/shopware-ats` both symlinking into it, so no single tool directory "owns" the shared
+content. We deferred that for two consumers since the current setup already isolates tool-specific
+metadata; revisit it once a third tool (Cursor, Windsurf, etc.) needs to consume this skill.
+
 ## Purpose
 
 Use this guide to:

--- a/USAGE.md
+++ b/USAGE.md
@@ -27,6 +27,12 @@ into a neutral top-level directory (e.g. `skills/shopware-ats/`), with `.codex/s
 content. We deferred that for two consumers since the current setup already isolates tool-specific
 metadata; revisit it once a third tool (Cursor, Windsurf, etc.) needs to consume this skill.
 
+**Windows caveat:** the `.claude/skills/shopware-ats/` symlinks resolve natively on Linux/WSL and
+macOS. On native Windows they only work with Git symlink support enabled (Developer Mode, or
+`core.symlinks=true`); otherwise they check out as dead text files containing the target path, and
+the skill silently fails to load for Claude. Codex is unaffected since `.codex/skills/shopware-ats/`
+holds real files, not symlinks.
+
 ## Purpose
 
 Use this guide to:


### PR DESCRIPTION
## What

Make the existing `shopware-ats` skill (currently only under `.codex/skills/`) discoverable by **Claude Code** as well, without duplicating content.

- Add `.claude/skills/shopware-ats/{SKILL.md,references}` as **targeted relative symlinks** into `.codex/skills/shopware-ats/` -> single source of truth for the tool-agnostic content; both agents read the same `SKILL.md` + `references/`.
- Deliberately do **not** mirror `.codex/skills/shopware-ats/agents/openai.yaml` (Codex-only agent manifest) — a full-directory symlink would have leaked it into Claude's view.
- Add `.claude/agents/shopware-ats.md` as Claude's own equivalent of `agents/openai.yaml` (display name, description, default prompt), living in Claude's own `agents/` directory instead of inside the shared skill tree.
- Make the skill `description` agent-neutral (`Codex` -> `you`) so it reads correctly for both.

## Why

Claude Code discovers project skills under `.claude/skills/`, Codex under `.codex/skills/`, and each tool has its own convention for agent-level metadata (`agents/openai.yaml` for Codex, `.claude/agents/*.md` for Claude). Symlinking only the tool-agnostic files (`SKILL.md`, `references/`) keeps one canonical copy of the shared behavior while letting each tool keep its own agent manifest separate and invisible to the other.

## Considered and deferred: neutral shared directory

We discussed going one step further — moving the shared content into a tool-agnostic top-level directory (e.g. `skills/shopware-ats/`), with both `.codex/skills/shopware-ats` and `.claude/skills/shopware-ats` symlinking into it, so neither tool directory "owns" the shared content. That's the cleaner model once a **third** tool needs this skill.

For now, with only two consumers, keeping `.codex/skills/shopware-ats/` as the real source of truth (as documented in `USAGE.md`) and having Claude symlink selectively into it is simpler, and avoids having to re-verify that Codex resolves a symlinked `SKILL.md` correctly. Revisit this if/when a third tool (Cursor, Windsurf, etc.) needs to consume the skill.

## Portability caveat (please flag if relevant)

The symlinks resolve natively on **Linux/WSL and macOS**. On **native Windows** they only work when Git symlink support is enabled (Developer Mode, or `core.symlinks=true`); otherwise they check out as dead text files containing the target path and the skill silently will not load.
