### PR TITLE
fix(flow): wait for flow-actions.json before opening action select

### DIFF
--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -8,7 +8,7 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
     CreateFlow: async ({ AdminFlowBuilderCreate, AdminFlowBuilderDetail, AdminFlowBuilderListing, ShopAdmin, TestDataService }, use) => {
         const task = (flowConfig: FlowConfig) => {
             return async function createFlow() {
-                // Wait for the flow-actions.json response to ensure the action dropdown is populated once it is opened.
+                // Listens for the flow-actions.json response to ensure the action dropdown is populated once it is needed.
                 const flowActionsLoaded = AdminFlowBuilderCreate.page.waitForResponse((response) => response.url().includes("/_info/flow-actions.json") && response.ok());
 
                 await AdminFlowBuilderListing.createFlowButton.click();
@@ -36,6 +36,7 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                     .click();
                 //await (await AdminFlowBuilderCreate.getSelectFieldListitem(AdminFlowBuilderCreate.conditionSelectField, `${flowConfig.condition}`)).click();
                 // Add action to condition true block
+                // waits for flow-actions.json response to ensure its populated
                 await flowActionsLoaded;
                 await AdminFlowBuilderCreate.trueBlockAddActionButton.click();
                 // todo: As soon as trueBlockActionSelectField is migrated to Meteor, remove the following three lines and use the commented line instead.

--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -8,6 +8,9 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
     CreateFlow: async ({ AdminFlowBuilderCreate, AdminFlowBuilderDetail, AdminFlowBuilderListing, ShopAdmin, TestDataService }, use) => {
         const task = (flowConfig: FlowConfig) => {
             return async function createFlow() {
+                // Wait for the flow-actions.json response to ensure the action dropdown is populated once it is opened.
+                const flowActionsLoaded = AdminFlowBuilderCreate.page.waitForResponse((response) => response.url().includes("/_info/flow-actions.json") && response.ok());
+
                 await AdminFlowBuilderListing.createFlowButton.click();
                 // Fill out fields on general tab
                 await ShopAdmin.expects(AdminFlowBuilderCreate.smartBarHeader).toHaveText(translate("administration:flowBuilder:create.newFlow"));
@@ -33,6 +36,7 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                     .click();
                 //await (await AdminFlowBuilderCreate.getSelectFieldListitem(AdminFlowBuilderCreate.conditionSelectField, `${flowConfig.condition}`)).click();
                 // Add action to condition true block
+                await flowActionsLoaded;
                 await AdminFlowBuilderCreate.trueBlockAddActionButton.click();
                 // todo: As soon as trueBlockActionSelectField is migrated to Meteor, remove the following three lines and use the commented line instead.
                 await AdminFlowBuilderCreate.trueBlockActionSelectField.click();

--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -36,7 +36,6 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                     .click();
                 //await (await AdminFlowBuilderCreate.getSelectFieldListitem(AdminFlowBuilderCreate.conditionSelectField, `${flowConfig.condition}`)).click();
                 // Add action to condition true block
-                // waits for flow-actions.json response to ensure its populated
                 await flowActionsLoaded;
                 await AdminFlowBuilderCreate.trueBlockAddActionButton.click();
                 // todo: As soon as trueBlockActionSelectField is migrated to Meteor, remove the following three lines and use the commented line instead.


### PR DESCRIPTION
### Summary

The action select dropdowns in `CreateFlow` (true/false block) could be opened before `GET /_info/flow-actions.json` had resolved. Shopware's `sw-single-select` only snapshots its `options` when the dropdown is opened, so opening it early leaves it permanently stuck showing "No results found" — even after the response arrives — because there is no reactive re-sync while it stays open. Playwright then retries clicking a list item that never appears until the test times out.

This was root-caused via a Playwright trace from a failing SaaS run: the click on the "Send email" item landed before the `flow-actions.json` response completed, and the UI stayed frozen on the empty dropdown until the test timeout closed the page.

### What changed

`CreateFlow` now registers a `page.waitForResponse()` for `flow-actions.json` at the start of the task (before the request can fire) and awaits it right before the true-block action select is opened for the first time, closing the race instead of relying on timing.

### Related

This was the root cause of the long-standing `test.skip(InstanceMeta.isSaaS, ...)` in `FlowBuilderCreate.spec.ts` in shopware/shopware. Companion PR removing that skip: shopware/shopware#19420
Original issue: https://github.com/shopware/shopware/issues/15749