### PR TITLE
feat: add optional boolean to selectsRadioButton for exact string matching

### DIFF
--- a/src/services/Actor.ts
+++ b/src/services/Actor.ts
@@ -57,11 +57,12 @@ export class Actor {
         });
     }
 
-    async selectsRadioButton(radioGroup: Locator, inputLabel: string) {
+    async selectsRadioButton(radioGroup: Locator, inputLabel: string, strictMatch?: boolean ) {
         const stepTitle = `${this.name} selects radio button ${inputLabel}`;
 
         await test.step(stepTitle, async () => {
-            const desiredOption = radioGroup.getByRole("radio", { name: inputLabel });
+            let defaultStrictMatch = false;
+            const desiredOption = radioGroup.getByRole("radio", { name: inputLabel, exact: strictMatch ?? defaultStrictMatch });
 
             if (await desiredOption.isChecked()) {
                 await this.a11y_checks(desiredOption);


### PR DESCRIPTION
Currently, if 2 radio buttons share similar enough names, Playwright (correctly) throws an error, as it resolves to 2 different locators. An example is the `ProductReviews.spec.ts` test, which has radio buttons labeled `Good` and `Very good`. If you pass `Good` as the `inputLabel`, Playwright will not know which one of the 2 radio buttons you want. 

This sets an optional `exact` parameter to `false` (same as Playwright default) which can be overridden as needed.