### PR TITLE
feat: add expandAdminMenu visual test helper

### DIFF
--- a/src/services/VisualTestHelpers.ts
+++ b/src/services/VisualTestHelpers.ts
@@ -329,29 +329,7 @@ const ADMIN_MENU_EXPANDED_STORAGE_KEY = "sw-admin-menu-expanded";
 
 /**
  * Forces the admin navigation sidebar back into its expanded state for the given page.
- *
- * The sidebar's expanded/collapsed state is read from localStorage on app boot
- * (`isExpanded: localStorage.getItem('sw-admin-menu-expanded') !== 'false'`), which defaults to
- * *expanded* whenever the key is absent. Some admin pages (e.g. the CMS/layout builder) call
- * `collapseSidebar()` unconditionally on mount and never call `expandSidebar()` afterwards - so
- * once a spec visits one of those pages, the collapsed flag persists in localStorage for the
- * rest of the browser context's lifetime.
- *
- * That matters for visual tests asserting a screenshot of `.sw-desktop__content` (see
- * `assertScreenshot` below), whose width depends on this state (300px expanded vs. 80px
- * collapsed sidebar = 220px width diff) - and for suites that reuse one `BrowserContext` across
- * multiple tests (e.g. a worker-scoped session), where the flag left behind by one test leaks
- * into every other test that runs afterwards in that same context.
- *
- * Call this once a spec that visits such a page is done, so the sidebar is restored before any
- * other test can inherit the collapsed state.
- *
- * `page.reload()`, not `addInitScript`, is what actually applies this: the admin app has
- * typically already booted by the time a spec is done, and some navigation helpers move between
- * admin routes via `document.location = "#/..."` rather than a real page load, which never
- * re-triggers app boot - so an `addInitScript` registered at that point would never fire again
- * within the same test. A real reload is the only thing that flips the already-booted app's
- * live state immediately.
+ * Reloads the page afterwards, since the app only picks up the flag on boot.
  *
  * @param page - Playwright page object
  */

--- a/src/services/VisualTestHelpers.ts
+++ b/src/services/VisualTestHelpers.ts
@@ -325,6 +325,43 @@ export async function setViewport(page: Page, options: Options = {}): Promise<vo
     return;
 }
 
+const ADMIN_MENU_EXPANDED_STORAGE_KEY = "sw-admin-menu-expanded";
+
+/**
+ * Forces the admin navigation sidebar back into its expanded state for the given page.
+ *
+ * The sidebar's expanded/collapsed state is read from localStorage on app boot
+ * (`isExpanded: localStorage.getItem('sw-admin-menu-expanded') !== 'false'`), which defaults to
+ * *expanded* whenever the key is absent. Some admin pages (e.g. the CMS/layout builder) call
+ * `collapseSidebar()` unconditionally on mount and never call `expandSidebar()` afterwards - so
+ * once a spec visits one of those pages, the collapsed flag persists in localStorage for the
+ * rest of the browser context's lifetime.
+ *
+ * That matters for visual tests asserting a screenshot of `.sw-desktop__content` (see
+ * `assertScreenshot` below), whose width depends on this state (300px expanded vs. 80px
+ * collapsed sidebar = 220px width diff) - and for suites that reuse one `BrowserContext` across
+ * multiple tests (e.g. a worker-scoped session), where the flag left behind by one test leaks
+ * into every other test that runs afterwards in that same context.
+ *
+ * Call this once a spec that visits such a page is done, so the sidebar is restored before any
+ * other test can inherit the collapsed state.
+ *
+ * `page.reload()`, not `addInitScript`, is what actually applies this: the admin app has
+ * typically already booted by the time a spec is done, and some navigation helpers move between
+ * admin routes via `document.location = "#/..."` rather than a real page load, which never
+ * re-triggers app boot - so an `addInitScript` registered at that point would never fire again
+ * within the same test. A real reload is the only thing that flips the already-booted app's
+ * live state immediately.
+ *
+ * @param page - Playwright page object
+ */
+export async function expandAdminMenu(page: Page): Promise<void> {
+    await page.evaluate((key: string) => {
+        localStorage.setItem(key, "true");
+    }, ADMIN_MENU_EXPANDED_STORAGE_KEY);
+    await page.reload();
+}
+
 /**
  * Takes a screenshot of the desktop content of the page or the provided locator and compares it to existing ones.
  *


### PR DESCRIPTION
### Why

The admin sidebar's expand/collapse state lives in `localStorage` and defaults to *expanded*. Two things can flip it to collapsed and leave it that way:

- Some admin pages (CMS/layout builder) call `collapseSidebar()` on mount and never call `expandSidebar()`.
- `sw-admin-menu`'s own resize listener auto-collapses whenever the viewport is <=1200px - which a helper that auto-sizes the viewport to page content (e.g. this package's `setViewport()`) can trigger on any narrow-content page.

In suites that reuse one `BrowserContext` across tests (worker-scoped sessions, single-worker CI), whichever collapses first leaks the flag into every visual test that runs afterwards - making `.sw-desktop__content` screenshots non-deterministic (300px vs. 80px sidebar = 220px width diff).

Hit this in shopware/shopware ([shopware/shopware#19532](https://github.com/shopware/shopware/pull/19532)). The helper has no shopware/shopware-specific logic, so any repo using this package for visual tests (e.g. Commercial) could hit the same leak.

### What this does

Adds `expandAdminMenu(page)` to `VisualTestHelpers.ts`, exported via the existing `export *` in `src/index.ts`. Uses `page.reload()` rather than `addInitScript`, since the app has usually already booted by the time this runs.

Recommended usage: call it unconditionally before every visual test (e.g. a `page` fixture override scoped to the visual project), not just after a fixed list of known offenders - covers pages you don't know trigger this yet. shopware/shopware#19532 does it this way.

Once released, shopware/shopware's local copy can be dropped for this package's version.

### Verification

`typecheck`, `lint`, `build` pass; `expandAdminMenu` shows up in `dist/index.mjs`. Validated against a real Shopware instance via this PR's pkg.pr.new preview build in shopware/shopware.