### PR TITLE
fix: expand admin sidebar via the store action, not a localStorage key

### DIFF
--- a/src/services/VisualTestHelpers.ts
+++ b/src/services/VisualTestHelpers.ts
@@ -325,19 +325,18 @@ export async function setViewport(page: Page, options: Options = {}): Promise<vo
     return;
 }
 
-const ADMIN_MENU_EXPANDED_STORAGE_KEY = "sw-admin-menu-expanded";
-
 /**
- * Forces the admin navigation sidebar back into its expanded state for the given page.
- * Reloads the page afterwards, since the app only picks up the flag on boot.
+ * Forces the admin navigation sidebar back into its expanded state for the given page. Calls the
+ * app's own store action rather than writing localStorage directly, so this doesn't depend on
+ * (and can't drift out of sync with) whichever key the app currently persists that flag under.
  *
  * @param page - Playwright page object
  */
 export async function expandAdminMenu(page: Page): Promise<void> {
-    await page.evaluate((key: string) => {
-        localStorage.setItem(key, "true");
-    }, ADMIN_MENU_EXPANDED_STORAGE_KEY);
-    await page.reload();
+    await page.evaluate(() => {
+        // @ts-expect-error - window.Shopware is set by the admin app itself, not declared here
+        window.Shopware.Store.get("adminMenu").expandSidebar();
+    });
 }
 
 /**


### PR DESCRIPTION
### Why

`expandAdminMenu()` (added in #684, released in 12.18.0) wrote directly to a hardcoded localStorage key to force the admin sidebar expanded. shopware/shopware's admin-ui-shell-rework ([shopware/shopware#15271](https://github.com/shopware/shopware/pull/15271)) renamed that key (`sw-admin-menu-expanded` -> `sw-admin-menu-sidebar-expanded`), silently breaking the helper - it kept writing to the old, now-unused key.

### What this does

Calls `Shopware.Store.get('adminMenu').expandSidebar()` via `page.evaluate()` instead - the app's own action for this, exposed on `window.Shopware`. Two benefits:
- Can't drift out of sync with whatever key the app persists this under internally, since we're not reimplementing that logic.
- No longer needs `page.reload()` - it flips the live reactive state directly rather than waiting for the app to re-read localStorage on boot, so it's simpler and faster.

### Verification

`npm run typecheck`, `npm run lint`, `npm run build` all pass; `expandAdminMenu` still shows up correctly in `dist/index.mjs`.