### PR TITLE
fix: scope LayoutCreate backButton to the wizard container

### DIFF
--- a/src/page-objects/administration/LayoutCreate.ts
+++ b/src/page-objects/administration/LayoutCreate.ts
@@ -35,7 +35,7 @@ export class LayoutCreate implements PageObject {
 
         this.fullWidthButton = page.getByRole("button", { name: translate("administration:layout:create.fullWidth") });
         this.sidebarButton = page.getByRole("button", { name: translate("administration:layout:create.sidebar") });
-        this.backButton = page.getByRole("button", { name: translate("administration:layout:create.back") });
+        this.backButton = page.locator(".sw-cms-create-wizard").getByRole("button", { name: translate("administration:layout:create.back") });
 
         this.layoutNameInput = page.getByRole("textbox", { name: translate("administration:layout:create.layoutName") });
         this.createLayoutButton = page.getByRole("button", { name: translate("administration:layout:create.createLayout") });


### PR DESCRIPTION
## Why

`shopware/shopware`'s `CreateProductListingLayout.spec.ts` visual test fails after the admin-ui-shell-rework (shopware/shopware#15271): the CMS detail page's back button became an `mt-button` (`role="button"`), so the previously unscoped `page.getByRole("button", { name: "Back" })` now matches two elements (the wizard's own back element + the detail page's back button) and throws a strict mode violation.

## What

Scopes `backButton` to the `.sw-cms-create-wizard` container so it only ever matches the wizard's own back element.