### PR TITLE
fix: assign domain currencies to sales channels

### DIFF
--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -1102,6 +1102,8 @@ export class TestDataService {
 
         const salesChannelDomainStruct = this.getSalesChannelDomainStruct(salesChannelId, currencyId, languageId, snippetSetId, overrides);
 
+        await this.assignSalesChannelCurrency(salesChannelId, currencyId);
+
         const response = await this.AdminApiClient.post(`sales-channel-domain?_response=detail`, {
             data: salesChannelDomainStruct,
         });

--- a/src/services/TestDataService.ts
+++ b/src/services/TestDataService.ts
@@ -1102,8 +1102,6 @@ export class TestDataService {
 
         const salesChannelDomainStruct = this.getSalesChannelDomainStruct(salesChannelId, currencyId, languageId, snippetSetId, overrides);
 
-        await this.assignSalesChannelCurrency(salesChannelId, currencyId);
-
         const response = await this.AdminApiClient.post(`sales-channel-domain?_response=detail`, {
             data: salesChannelDomainStruct,
         });
@@ -3019,6 +3017,10 @@ export class TestDataService {
             currencyId: currencyId,
             languageId: languageId,
             snippetSetId: snippetSetId,
+            salesChannel: {
+                id: salesChannelId,
+                currencies: [{ id: currencyId }],
+            },
         };
 
         return Object.assign({}, basicSalesChannelDomain, overrides);

--- a/tests/TestDataService/TestDataService.spec.ts
+++ b/tests/TestDataService/TestDataService.spec.ts
@@ -19,6 +19,7 @@ import {
     type User,
     type AclRole,
     type CmsPage,
+    type SalesChannel,
 } from "../../src";
 
 test("Data Service", async ({ TestDataService, AdminApiContext }) => {
@@ -45,16 +46,14 @@ test("Data Service", async ({ TestDataService, AdminApiContext }) => {
     expect(currency.taxFreeFrom).toEqual(10);
 
     const salesChannelDomain = await TestDataService.createSalesChannelDomain();
-    const salesChannelCurrencyResponse = await AdminApiContext.post("./search/sales-channel-currency", {
+    const salesChannelResponse = await AdminApiContext.post("./search/sales-channel", {
         data: {
-            filter: [
-                { type: "equals", field: "salesChannelId", value: TestDataService.defaultSalesChannel.id },
-                { type: "equals", field: "currencyId", value: salesChannelDomain.currencyId },
-            ],
+            filter: [{ type: "equals", field: "id", value: TestDataService.defaultSalesChannel.id }],
+            associations: { currencies: {} },
         },
     });
-    const { data: salesChannelCurrencies } = (await salesChannelCurrencyResponse.json()) as { data: unknown[] };
-    expect(salesChannelCurrencies).toHaveLength(1);
+    const { data: salesChannels } = (await salesChannelResponse.json()) as { data: SalesChannel[] };
+    expect(salesChannels[0].currencies).toContainEqual(expect.objectContaining({ id: salesChannelDomain.currencyId }));
 
     const country = await TestDataService.createCountry();
     expect(country.name).toBeDefined();

--- a/tests/TestDataService/TestDataService.spec.ts
+++ b/tests/TestDataService/TestDataService.spec.ts
@@ -44,6 +44,18 @@ test("Data Service", async ({ TestDataService, AdminApiContext }) => {
     const currency = await TestDataService.createCurrency({ taxFreeFrom: 10 });
     expect(currency.taxFreeFrom).toEqual(10);
 
+    const salesChannelDomain = await TestDataService.createSalesChannelDomain();
+    const salesChannelCurrencyResponse = await AdminApiContext.post("./search/sales-channel-currency", {
+        data: {
+            filter: [
+                { type: "equals", field: "salesChannelId", value: TestDataService.defaultSalesChannel.id },
+                { type: "equals", field: "currencyId", value: salesChannelDomain.currencyId },
+            ],
+        },
+    });
+    const { data: salesChannelCurrencies } = (await salesChannelCurrencyResponse.json()) as { data: unknown[] };
+    expect(salesChannelCurrencies).toHaveLength(1);
+
     const country = await TestDataService.createCountry();
     expect(country.name).toBeDefined();
 


### PR DESCRIPTION
## What does this PR do?

Assign the currency selected for a generated sales-channel domain before creating the domain. This keeps the fixture valid when a platform version validates domain currencies against the sales channel assignment.

## How was it tested?

- `npm run typecheck`
- `npm run lint`