### PR TITLE
fix: locate the flow builder tabs by role

### DIFF
--- a/src/locales/de/administration/flowBuilder.json
+++ b/src/locales/de/administration/flowBuilder.json
@@ -17,7 +17,9 @@
         "description": "Beschreibung",
         "priority": "Priority",
         "active": "Aktiv",
-        "tags": "Tags"
+        "tags": "Tags",
+        "tabGeneral": "Allgemein",
+        "tabFlow": "Flow"
     },
     "detail": {
         "priority": "Priorität",

--- a/src/locales/en/administration/flowBuilder.json
+++ b/src/locales/en/administration/flowBuilder.json
@@ -14,7 +14,9 @@
         "description": "Description",
         "priority": "Priority",
         "active": "Active",
-        "tags": "Tags"
+        "tags": "Tags",
+        "tabGeneral": "General",
+        "tabFlow": "Flow"
     },
     "detail": {
         "name": "Name"

--- a/src/page-objects/administration/FlowBuilderCreate.ts
+++ b/src/page-objects/administration/FlowBuilderCreate.ts
@@ -58,9 +58,10 @@ export class FlowBuilderCreate implements PageObject {
         this.saveButton = page.locator(".sw-flow-detail__save");
         this.header = page.locator("h2");
         this.smartBarHeader = page.locator(".smart-bar__header");
-        this.generalTab = page.locator(".sw-flow-detail__tab-general");
+        const tabList = page.getByRole("tablist");
+        this.generalTab = tabList.getByRole("tab", { name: translate("administration:flowBuilder:create.tabGeneral"), exact: true });
         this.triggerSelectField = page.locator(".sw-flow-detail-flow__trigger-card").getByRole("textbox");
-        this.flowTab = page.locator(".sw-tabs__content").locator(".sw-flow-detail__tab-flow");
+        this.flowTab = tabList.getByRole("tab", { name: translate("administration:flowBuilder:create.tabFlow"), exact: true });
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.modalAddButton = page.locator(".sw-button--primary").getByText(translate("administration:flowBuilder:create.addAction"));
         } else {

--- a/src/page-objects/administration/FlowBuilderDetail.ts
+++ b/src/page-objects/administration/FlowBuilderDetail.ts
@@ -9,8 +9,6 @@ import { translate } from "../../services/LanguageHelper";
 export class FlowBuilderDetail extends FlowBuilderCreate implements PageObject {
     public readonly saveButtonLoader: Locator;
     public readonly saveButton: Locator;
-    public readonly generalTab: Locator;
-    public readonly flowTab: Locator;
     public readonly alertWarning: Locator;
     public readonly templateName: Locator;
     public readonly alertMessage: Locator;
@@ -21,7 +19,6 @@ export class FlowBuilderDetail extends FlowBuilderCreate implements PageObject {
 
     constructor(page: Page, instanceMeta: HelperFixtureTypes["InstanceMeta"]) {
         super(page, instanceMeta);
-        this.generalTab = page.locator(".sw-flow-detail__tab-general");
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.successMessage = page.locator(".sw-alert__title");
             this.saveButtonLoader = page.locator(".sw-button--primary").locator(".sw-button_loader");
@@ -34,7 +31,6 @@ export class FlowBuilderDetail extends FlowBuilderCreate implements PageObject {
             this.alertMessage = page.locator(".mt-banner__title");
         }
         this.saveButton = page.locator(".sw-flow-detail__save");
-        this.flowTab = page.locator(".sw-flow-detail__tab-flow");
         this.templateName = page.getByLabel(translate("administration:flowBuilder:detail.name"));
         this.actionContentTag = page.locator(".sw-flow-sequence-action__content").locator(".tag");
         this.skeletonLoader = page.locator(".sw-skeleton");


### PR DESCRIPTION
## What?

`FlowBuilderCreate` and `FlowBuilderDetail` now locate the flow detail tabs by their ARIA role instead of by CSS class.

```diff
-this.generalTab = page.locator(".sw-flow-detail__tab-general");
-this.flowTab = page.locator(".sw-tabs__content").locator(".sw-flow-detail__tab-flow");
+const tabList = page.getByRole("tablist");
+this.generalTab = tabList.getByRole("tab", { name: translate("administration:flowBuilder:create.tabGeneral"), exact: true });
+this.flowTab = tabList.getByRole("tab", { name: translate("administration:flowBuilder:create.tabFlow"), exact: true });
```

## Why?

Under the `v6.8.0.0` feature flag the flow detail page renders its tabs with `mt-tabs` rather than `sw-tabs`:

```twig
<template v-if="feature.isActive('v6.8.0.0')">
    <mt-tabs position-identifier="sw-flow-detail" :items="flowDetailTabs" :small="true" />
</template>
<template v-else>
    <sw-tabs position-identifier="sw-flow-detail">
        <sw-tabs-item class="sw-flow-detail__tab-flow" :route="routeDetailTab('flow')">
```

`mt-tabs` builds its items from a prop, so neither `.sw-tabs__content` nor the per-tab classes exist any more. `CreateFlow` calls `flowTab.click()` as its first step, so the whole task times out there on a major run, well before it reaches the parts of the flow it is meant to cover.

Measured on a 6.8 instance, before this change:

```
Test timeout of 60000ms exceeded.
Error: locator.click: Target page, context or browser has been closed
Call log:
  - waiting for locator('.sw-tabs__content').locator('.sw-flow-detail__tab-flow')
```

## How?

Both implementations mark the tab strip with `role="tablist"` and each tab with `role="tab"`, so one role based locator covers either markup and no version branch is needed:

- `mt-tabs` renders `<div class="mt-tabs" role="tablist">` containing `<button class="mt-tabs__item" role="tab">Flow</button>`.
- `sw-tabs` renders `.sw-tabs__content` with `role="tablist"`, and `sw-tabs-item` renders `role="tab"` in both its native and its router-link branch.

The accessible name is the tab label, so the two new translation keys `create.tabGeneral` and `create.tabFlow` keep the locators working in German runs as well.

`FlowBuilderDetail` extends `FlowBuilderCreate` but redeclared both tab locators with the same stale selectors. It now inherits them, so the fix cannot drift apart between the two page objects.

## Testing?

Against a 6.8 Shopware instance (`FEATURE_ALL=major`, admin built from that flag) with this build linked in:

- Before: `FlowBuilderCreate.spec.ts` times out on the Flow tab click, as quoted above.
- After: the tab click succeeds and the task runs on through the trigger, the condition and the first action.

The run does not reach the end on my instance: it later waits for a freshly created tag in the tag select, which loads only the first 25 tags unsorted, and that shop has more. That is instance data rather than a locator problem, and it is unrelated to this change.

## Anything Else?

This is the second selector in this package that the 6.8 component migrations invalidated, after the First Run Wizard sales channel list in #579. Others may be worth an audit — the pattern is a Shopware class name that only the pre-6.8 component renders.
