### PR TITLE
fix(flow): use mt-tabs locators for flow detail tabs behind v6.8.0.0

### DIFF
--- a/src/page-objects/administration/FlowBuilderCreate.ts
+++ b/src/page-objects/administration/FlowBuilderCreate.ts
@@ -58,9 +58,16 @@ export class FlowBuilderCreate implements PageObject {
         this.saveButton = page.locator(".sw-flow-detail__save");
         this.header = page.locator("h2");
         this.smartBarHeader = page.locator(".smart-bar__header");
-        this.generalTab = page.locator(".sw-flow-detail__tab-general");
         this.triggerSelectField = page.locator(".sw-flow-detail-flow__trigger-card").getByRole("textbox");
-        this.flowTab = page.locator(".sw-tabs__content").locator(".sw-flow-detail__tab-flow");
+        //TODO: After 6.8.0.0 release if condition needs to be replaced with 'satisfies(instanceMeta.version, ">=6.8")'
+        if (instanceMeta.features["V6_8_0_0"]) {
+            this.generalTab = page.locator('.mt-tabs__item[data-item-name="sw.flow.create.general"]');
+            this.flowTab = page.locator('.mt-tabs__item[data-item-name="sw.flow.create.flow"]');
+        } else {
+            this.generalTab = page.locator(".sw-flow-detail__tab-general");
+            this.flowTab = page.locator(".sw-tabs__content").locator(".sw-flow-detail__tab-flow");
+        }
+        //TODO: After 6.8.0.0 release this condition can be removed. Only the else branch is needed then
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.modalAddButton = page.locator(".sw-button--primary").getByText(translate("administration:flowBuilder:create.addAction"));
         } else {

--- a/src/page-objects/administration/FlowBuilderDetail.ts
+++ b/src/page-objects/administration/FlowBuilderDetail.ts
@@ -21,7 +21,15 @@ export class FlowBuilderDetail extends FlowBuilderCreate implements PageObject {
 
     constructor(page: Page, instanceMeta: HelperFixtureTypes["InstanceMeta"]) {
         super(page, instanceMeta);
-        this.generalTab = page.locator(".sw-flow-detail__tab-general");
+        //TODO: After 6.8.0.0 release if condition needs to be replaced with 'satisfies(instanceMeta.version, ">=6.8")'
+        if (instanceMeta.features["V6_8_0_0"]) {
+            this.generalTab = page.locator('.mt-tabs__item[data-item-name="sw.flow.detail.general"]');
+            this.flowTab = page.locator('.mt-tabs__item[data-item-name="sw.flow.detail.flow"]');
+        } else {
+            this.generalTab = page.locator(".sw-flow-detail__tab-general");
+            this.flowTab = page.locator(".sw-flow-detail__tab-flow");
+        }
+        //TODO: After 6.8.0.0 release this condition can be removed. Only the else branch is needed then
         if (satisfies(instanceMeta.version, "<6.7")) {
             this.successMessage = page.locator(".sw-alert__title");
             this.saveButtonLoader = page.locator(".sw-button--primary").locator(".sw-button_loader");
@@ -34,7 +42,6 @@ export class FlowBuilderDetail extends FlowBuilderCreate implements PageObject {
             this.alertMessage = page.locator(".mt-banner__title");
         }
         this.saveButton = page.locator(".sw-flow-detail__save");
-        this.flowTab = page.locator(".sw-flow-detail__tab-flow");
         this.templateName = page.getByLabel(translate("administration:flowBuilder:detail.name"));
         this.actionContentTag = page.locator(".sw-flow-sequence-action__content").locator(".tag");
         this.skeletonLoader = page.locator(".sw-skeleton");

--- a/src/page-objects/administration/FlowBuilderTemplates.ts
+++ b/src/page-objects/administration/FlowBuilderTemplates.ts
@@ -23,8 +23,6 @@ export class FlowBuilderTemplates extends FlowBuilderListing implements PageObje
         };
     }
 
-    // Waits for the search-triggered /api/search/flow-template request matching searchTerm to
-    // resolve before resolving the row, so the row lookup does not race the grid re-render.
     async searchLineItemByFlowName(searchTerm: string, flowName: string) {
         const searchResponse = this.page.waitForResponse((response) => {
             if (!response.url().includes("/api/search/flow-template") || response.request().method() !== "POST") {

--- a/src/page-objects/administration/FlowBuilderTemplates.ts
+++ b/src/page-objects/administration/FlowBuilderTemplates.ts
@@ -29,6 +29,10 @@ export class FlowBuilderTemplates extends FlowBuilderListing implements PageObje
                 return false;
             }
 
+            if (!response.ok()) {
+                return false;
+            }
+
             const requestData = response.request().postDataJSON() as { term?: string } | null;
 
             return requestData?.term === searchTerm;

--- a/src/page-objects/administration/FlowBuilderTemplates.ts
+++ b/src/page-objects/administration/FlowBuilderTemplates.ts
@@ -22,4 +22,23 @@ export class FlowBuilderTemplates extends FlowBuilderListing implements PageObje
             templateDetailLink: templateDetailLink,
         };
     }
+
+    // Waits for the search-triggered /api/search/flow-template request matching searchTerm to
+    // resolve before resolving the row, so the row lookup does not race the grid re-render.
+    async searchLineItemByFlowName(searchTerm: string, flowName: string) {
+        const searchResponse = this.page.waitForResponse((response) => {
+            if (!response.url().includes("/api/search/flow-template") || response.request().method() !== "POST") {
+                return false;
+            }
+
+            const requestData = response.request().postDataJSON() as { term?: string } | null;
+
+            return requestData?.term === searchTerm;
+        });
+
+        await this.searchBar.fill(searchTerm);
+        await searchResponse;
+
+        return this.getLineItemByFlowName(flowName);
+    }
 }


### PR DESCRIPTION
## Summary
- `sw-flow-detail.html.twig` switches from `sw-tabs` to `mt-tabs` once the `v6.8.0.0` feature flag is active, and `mt-tabs` no longer renders the `sw-flow-detail__tab-general`/`sw-flow-detail__tab-flow` classes `FlowBuilderCreate`/`FlowBuilderDetail` locators relied on. This broke `Settings/FlowBuilderCreate.spec.ts`, `Settings/FlowBuilderTemplates.spec.ts` and (indirectly) `Settings/FlowValidation.spec.ts` on the major nightly (shopware/shopware#18182, #18183, #18184).
- Both page objects now branch on `instanceMeta.features["V6_8_0_0"]` (the live flag state from `/api/_action/feature-flag`, so it also works under `FEATURE_ALL=major` on a still-6.7-versioned trunk) and use the `mt-tabs` item's stable `data-item-name` (Vue Router name) instead of the removed class.
- Added `FlowBuilderTemplates.searchLineItemByFlowName()` to replace a duplicated local search+wait helper that lived in the shopware/shopware spec, and it exposes the `createFlowLink`/`templateDetailLink` locators the spec was previously re-deriving via raw CSS classes.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Verified against a local trunk with `FEATURE_ALL=major` (mt-tabs branch) and with `FEATURE_ALL` unset (legacy sw-tabs branch): `Settings/FlowBuilderTemplates.spec.ts` passes in both modes after syncing this build into shopware/shopware's `tests/acceptance/node_modules/@shopware-ag/acceptance-test-suite/dist/`.

Companion PR in shopware/shopware (test refactor, depends on this being released): TBD
