### PR TITLE
fix(flow): make CreateFlow tag select robust to a large tag catalog

### DIFF
--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -71,8 +71,6 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                 await ShopAdmin.expects(AdminFlowBuilderCreate.tagModal).toBeVisible();
                 // todo: As soon as tagModalTagsSelectField is migrated to Meteor, remove the following four lines and use the commented line instead.
                 await AdminFlowBuilderCreate.tagModalTagsSelectField.click();
-                // Search server-side instead of relying on the unfiltered first page: with enough
-                // pre-existing tags in the shop, the freshly created tag can fall outside it.
                 await AdminFlowBuilderCreate.tagModalTagsSelectField.fill(flowConfig.falseActionIdentifier);
                 await ShopAdmin.expects(AdminFlowBuilderCreate.resultList).toBeVisible();
                 await AdminFlowBuilderCreate.resultListItem

--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -80,6 +80,9 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                     .filter({ hasText: `${flowConfig.falseActionIdentifier}` })
                     .click();
                 //await (await AdminFlowBuilderCreate.getSelectFieldListitem(AdminFlowBuilderCreate.tagModalTagsSelectField, `${flowConfig.falseActionIdentifier}`)).click();
+                // The tags select stays open after picking one (it's multi-select); with a long
+                // enough result list it can visually overlap and intercept the Add button below.
+                await AdminFlowBuilderCreate.tagModalTagsSelectField.press("Escape");
                 await AdminFlowBuilderCreate.modalAddButton.click();
                 await ShopAdmin.expects(AdminFlowBuilderCreate.falseBlockActionDescription).toContainText(`Tag: ${flowConfig.falseActionIdentifier}`);
                 await AdminFlowBuilderCreate.saveButton.click();

--- a/src/tasks/shop-admin/Flow/CreateFlow.ts
+++ b/src/tasks/shop-admin/Flow/CreateFlow.ts
@@ -69,8 +69,11 @@ export const CreateFlow = base.extend<{ CreateFlow: Task }, FixtureTypes>({
                     .click();
                 //await (await AdminFlowBuilderCreate.getSelectFieldListitem(AdminFlowBuilderCreate.falseBlockActionSelectField, `${flowConfig.falseAction}`)).click();
                 await ShopAdmin.expects(AdminFlowBuilderCreate.tagModal).toBeVisible();
-                // todo: As soon as tagModalTagsSelectField is migrated to Meteor, remove the following three lines and use the commented line instead.
+                // todo: As soon as tagModalTagsSelectField is migrated to Meteor, remove the following four lines and use the commented line instead.
                 await AdminFlowBuilderCreate.tagModalTagsSelectField.click();
+                // Search server-side instead of relying on the unfiltered first page: with enough
+                // pre-existing tags in the shop, the freshly created tag can fall outside it.
+                await AdminFlowBuilderCreate.tagModalTagsSelectField.fill(flowConfig.falseActionIdentifier);
                 await ShopAdmin.expects(AdminFlowBuilderCreate.resultList).toBeVisible();
                 await AdminFlowBuilderCreate.resultListItem
                     .getByRole("listitem")


### PR DESCRIPTION
## Summary
Two related fixes to `CreateFlow`'s false-block tag select, both found while investigating `Settings/FlowBuilderCreate.spec.ts` failures under `FEATURE_ALL=major` (shopware/shopware#18182):

1. **Search server-side instead of relying on the unfiltered first page.** The select opened the dropdown and picked from whatever `/api/search/tag` returned for `term=""` (page 1, limit 25), instead of searching for the tag it had just created. With enough pre-existing tags in the shop, the freshly created tag falls outside that first page and the click on it never finds a match.
2. **Close the select before clicking "Add".** It's a multi-select, so picking a tag doesn't close the dropdown. With few tags that's harmless, but with a long enough result list the still-open dropdown visually overlaps the modal's Add button and intercepts the click. `Escape` closes it before that click.

## Test plan
- [x] `npm run typecheck`, `npm run build`
- [x] Isolated before/after verification: seeded a clean shop with 40 filler tags via `/api/_action/sync` (`AAA Filler Tag 01..40`, sorting ahead of the test's `Test tag - <uuid>`), then ran `Settings/FlowBuilderCreate.spec.ts` against that exact same DB state three times:
  - without either fix: fails (target tag never found in the unfiltered page)
  - with fix 1 only: fails differently (tag is found and selected, but the still-open dropdown intercepts the Add-button click)
  - with both fixes: passes, 4/4 with `--repeat-each=4`
